### PR TITLE
add timeHelper interface to avoid direct coupling with the time package

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -48,7 +48,6 @@ const (
 
 var (
 	locker Locker
-	th     = newTimeHelper()
 )
 
 // SetLocker sets a locker implementation

--- a/gocron.go
+++ b/gocron.go
@@ -48,6 +48,7 @@ const (
 
 var (
 	locker Locker
+	th     = newTimeHelper()
 )
 
 // SetLocker sets a locker implementation

--- a/job.go
+++ b/job.go
@@ -35,8 +35,8 @@ type Job struct {
 func NewJob(interval uint64) *Job {
 	return &Job{
 		interval: interval,
-		lastRun:  time.Unix(0, 0),
-		nextRun:  time.Unix(0, 0),
+		lastRun:  th.Unix(0, 0),
+		nextRun:  th.Unix(0, 0),
 		startDay: time.Sunday,
 		funcs:    make(map[string]interface{}),
 		fparams:  make(map[string][]interface{}),
@@ -46,12 +46,12 @@ func NewJob(interval uint64) *Job {
 
 // True if the job should be run now
 func (j *Job) shouldRun() bool {
-	return time.Now().Unix() >= j.nextRun.Unix()
+	return th.Now().Unix() >= j.nextRun.Unix()
 }
 
 //Run the job and immediately reschedule it
 func (j *Job) run() {
-	j.lastRun = time.Now()
+	j.lastRun = th.Now()
 	go callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
 }
 

--- a/job.go
+++ b/job.go
@@ -29,10 +29,12 @@ type Job struct {
 	fparams           map[string][]interface{} // Map for function and  params of function
 	lock              bool                     // lock the job from running at same time form multiple instances
 	tags              []string                 // allow the user to tag jobs with certain labels
+	time              timeHelper               // an instance of timeHelper to interact with the time package
 }
 
 // NewJob creates a new job with the time interval.
 func NewJob(interval uint64) *Job {
+	th := newTimeHelper()
 	return &Job{
 		interval: interval,
 		lastRun:  th.Unix(0, 0),
@@ -41,17 +43,18 @@ func NewJob(interval uint64) *Job {
 		funcs:    make(map[string]interface{}),
 		fparams:  make(map[string][]interface{}),
 		tags:     []string{},
+		time:     th,
 	}
 }
 
 // True if the job should be run now
 func (j *Job) shouldRun() bool {
-	return th.Now().Unix() >= j.nextRun.Unix()
+	return j.time.Now().Unix() >= j.nextRun.Unix()
 }
 
 //Run the job and immediately reschedule it
 func (j *Job) run() {
-	j.lastRun = th.Now()
+	j.lastRun = j.time.Now()
 	go callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -12,6 +12,7 @@ import (
 type Scheduler struct {
 	jobs []*Job
 	loc  *time.Location
+	time timeHelper // an instance of timeHelper to interact with the time package
 }
 
 // NewScheduler creates a new scheduler
@@ -19,6 +20,7 @@ func NewScheduler(loc *time.Location) *Scheduler {
 	return &Scheduler{
 		jobs: newEmptyJobSlice(),
 		loc:  loc,
+		time: newTimeHelper(),
 	}
 }
 
@@ -26,7 +28,7 @@ func NewScheduler(loc *time.Location) *Scheduler {
 // Add seconds ticker
 func (s *Scheduler) Start() chan struct{} {
 	stopped := make(chan struct{})
-	ticker := th.NewTicker(1 * time.Second)
+	ticker := s.time.NewTicker(1 * time.Second)
 
 	go func() {
 		for {
@@ -67,8 +69,8 @@ func (s *Scheduler) ChangeLoc(newLocation *time.Location) {
 
 // scheduleNextRun Compute the instant when this job should run next
 func (s *Scheduler) scheduleNextRun(j *Job) error {
-	now := th.Now().In(s.loc)
-	if j.lastRun == th.Unix(0, 0) {
+	now := s.time.Now().In(s.loc)
+	if j.lastRun == s.time.Unix(0, 0) {
 		j.lastRun = now
 	}
 
@@ -107,7 +109,7 @@ func (s *Scheduler) scheduleNextRun(j *Job) error {
 
 // roundToMidnight truncate time to midnight
 func (s *Scheduler) roundToMidnight(t time.Time) time.Time {
-	return th.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, s.loc)
+	return s.time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, s.loc)
 }
 
 // Get the current runnable jobs, which shouldRun is True
@@ -127,7 +129,7 @@ func (s *Scheduler) getRunnableJobs() []*Job {
 // NextRun datetime when the next job should run.
 func (s *Scheduler) NextRun() (*Job, time.Time) {
 	if len(s.jobs) <= 0 {
-		return nil, th.Now()
+		return nil, s.time.Now()
 	}
 	sort.Sort(s)
 	return s.jobs[0], s.jobs[0].nextRun
@@ -178,7 +180,7 @@ func (s *Scheduler) RunAllWithDelay(d int) {
 		if err != nil {
 			continue
 		}
-		th.Sleep(time.Duration(d) * time.Second)
+		s.time.Sleep(time.Duration(d) * time.Second)
 	}
 }
 
@@ -288,7 +290,7 @@ func (s *Scheduler) StartAt(t time.Time) *Scheduler {
 // StartImmediately sets the jobs next run as soon as the scheduler starts
 func (s *Scheduler) StartImmediately() *Scheduler {
 	job := s.getCurrentJob()
-	job.nextRun = th.Now().In(s.loc)
+	job.nextRun = s.time.Now().In(s.loc)
 	job.startsImmediately = true
 	return s
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -26,7 +26,7 @@ func NewScheduler(loc *time.Location) *Scheduler {
 // Add seconds ticker
 func (s *Scheduler) Start() chan struct{} {
 	stopped := make(chan struct{})
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := th.NewTicker(1 * time.Second)
 
 	go func() {
 		for {
@@ -67,8 +67,8 @@ func (s *Scheduler) ChangeLoc(newLocation *time.Location) {
 
 // scheduleNextRun Compute the instant when this job should run next
 func (s *Scheduler) scheduleNextRun(j *Job) error {
-	now := time.Now().In(s.loc)
-	if j.lastRun == time.Unix(0, 0) {
+	now := th.Now().In(s.loc)
+	if j.lastRun == th.Unix(0, 0) {
 		j.lastRun = now
 	}
 
@@ -107,7 +107,7 @@ func (s *Scheduler) scheduleNextRun(j *Job) error {
 
 // roundToMidnight truncate time to midnight
 func (s *Scheduler) roundToMidnight(t time.Time) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, s.loc)
+	return th.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, s.loc)
 }
 
 // Get the current runnable jobs, which shouldRun is True
@@ -127,7 +127,7 @@ func (s *Scheduler) getRunnableJobs() []*Job {
 // NextRun datetime when the next job should run.
 func (s *Scheduler) NextRun() (*Job, time.Time) {
 	if len(s.jobs) <= 0 {
-		return nil, time.Now()
+		return nil, th.Now()
 	}
 	sort.Sort(s)
 	return s.jobs[0], s.jobs[0].nextRun
@@ -178,7 +178,7 @@ func (s *Scheduler) RunAllWithDelay(d int) {
 		if err != nil {
 			continue
 		}
-		time.Sleep(time.Duration(d) * time.Second)
+		th.Sleep(time.Duration(d) * time.Second)
 	}
 }
 
@@ -288,7 +288,7 @@ func (s *Scheduler) StartAt(t time.Time) *Scheduler {
 // StartImmediately sets the jobs next run as soon as the scheduler starts
 func (s *Scheduler) StartImmediately() *Scheduler {
 	job := s.getCurrentJob()
-	job.nextRun = time.Now().In(s.loc)
+	job.nextRun = th.Now().In(s.loc)
 	job.startsImmediately = true
 	return s
 }

--- a/timeHelper.go
+++ b/timeHelper.go
@@ -1,0 +1,37 @@
+package gocron
+
+import "time"
+
+type timeHelper interface {
+	Now() time.Time
+	Unix(int64, int64) time.Time
+	Sleep(time.Duration)
+	Date(int, time.Month, int, int, int, int, int, *time.Location) time.Time
+	NewTicker(time.Duration) *time.Ticker
+}
+
+func newTimeHelper() timeHelper {
+	return &trueTime{}
+}
+
+type trueTime struct{}
+
+func (t *trueTime) Now() time.Time {
+	return time.Now()
+}
+
+func (t *trueTime) Unix(sec int64, nsec int64) time.Time {
+	return time.Unix(sec, nsec)
+}
+
+func (t *trueTime) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (t *trueTime) Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) time.Time {
+	return time.Date(year, month, day, hour, min, sec, nsec, loc)
+}
+
+func (t *trueTime) NewTicker(d time.Duration) *time.Ticker {
+	return time.NewTicker(d)
+}


### PR DESCRIPTION
Addressing #10 

Created a `timeHelper` interface to wrap the functions we are using from the `time` package. Not wrapping the constants like `time.Sunday` because I guess that's not necessary. 

We might not need to define a `mockTime` explicitly if we use a mocking tool like [Mockary](https://github.com/vektra/mockery).