### PR TITLE
fix bug in scheduler, rescheduling jobs immediately

### DIFF
--- a/job.go
+++ b/job.go
@@ -20,7 +20,6 @@ type Job struct {
 	fparams           map[string][]interface{} // Map for function and  params of function
 	lock              bool                     // lock the Job from running at same time form multiple instances
 	tags              []string                 // allow the user to tag Jobs with certain labels
-	time              timeHelper               // an instance of timeHelper to interact with the time package
 }
 
 // NewJob creates a new Job with the provided interval
@@ -34,18 +33,11 @@ func NewJob(interval uint64) *Job {
 		funcs:    make(map[string]interface{}),
 		fparams:  make(map[string][]interface{}),
 		tags:     []string{},
-		time:     th,
 	}
-}
-
-// shouldRun returns true if the Job should be run now
-func (j *Job) shouldRun() bool {
-	return j.time.Now().Unix() >= j.nextRun.Unix()
 }
 
 // Run the Job and immediately reschedule it
 func (j *Job) run() {
-	j.lastRun = j.time.Now()
 	go callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
 }
 

--- a/job.go
+++ b/job.go
@@ -38,7 +38,7 @@ func NewJob(interval uint64) *Job {
 
 // Run the Job and immediately reschedule it
 func (j *Job) run() {
-	go callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
+	callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
 }
 
 // Err returns an error if one ocurred while creating the Job

--- a/scheduler.go
+++ b/scheduler.go
@@ -72,7 +72,7 @@ func (s *Scheduler) SetLocation(newLocation *time.Location) {
 func (s *Scheduler) scheduleNextRun(j *Job) error {
 	now := s.time.NowRoundedDownToSeconds(s.loc)
 
-	if j.nextRun.Second() > now.Second() {
+	if j.nextRun.Unix() > now.Unix() {
 		return nil
 	}
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -70,7 +70,7 @@ func (s *Scheduler) SetLocation(newLocation *time.Location) {
 
 // scheduleNextRun Compute the instant when this Job should run next
 func (s *Scheduler) scheduleNextRun(j *Job) error {
-	now := s.time.NowRoundedDownToSeconds(s.loc)
+	now := s.time.Now(s.loc)
 
 	if j.nextRun.Unix() > now.Unix() {
 		return nil
@@ -127,7 +127,7 @@ func (s *Scheduler) getRunnableJobs() []*Job {
 // NextRun datetime when the next Job should run.
 func (s *Scheduler) NextRun() (*Job, time.Time) {
 	if len(s.jobs) <= 0 {
-		return nil, s.time.NowRoundedDownToSeconds(s.loc)
+		return nil, s.time.Now(s.loc)
 	}
 	sort.Sort(s)
 	return s.jobs[0], s.jobs[0].nextRun
@@ -158,7 +158,7 @@ func (s *Scheduler) runJob(job *Job) error {
 		locker.Lock(key)
 		defer locker.Unlock(key)
 	}
-	job.lastRun = s.time.NowRoundedDownToSeconds(s.loc)
+	job.lastRun = s.time.Now(s.loc)
 	job.run()
 	err := s.scheduleNextRun(job)
 	if err != nil {
@@ -257,7 +257,7 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 		}
 
 		if j.lastRun == s.time.Unix(0, 0) {
-			j.lastRun = s.time.NowRoundedDownToSeconds(s.loc)
+			j.lastRun = s.time.Now(s.loc)
 
 			if j.atTime != 0 {
 				j.lastRun = j.lastRun.Add(-periodDuration)
@@ -294,7 +294,7 @@ func (s *Scheduler) StartAt(t time.Time) *Scheduler {
 // StartImmediately sets the Jobs next run as soon as the scheduler starts
 func (s *Scheduler) StartImmediately() *Scheduler {
 	job := s.getCurrentJob()
-	job.nextRun = s.time.NowRoundedDownToSeconds(s.loc)
+	job.nextRun = s.time.Now(s.loc)
 	job.startsImmediately = true
 	return s
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -29,8 +29,8 @@ func TestExecutionSecond(t *testing.T) {
 func TestExecutionSeconds(t *testing.T) {
 	sched := NewScheduler(time.UTC)
 	jobDone := make(chan bool)
-	executionTimes := make([]int64, 0, 2)
-	numberOfIterations := 20
+	var executionTimes []int64
+	numberOfIterations := 2
 
 	sched.Every(2).Seconds().Do(func() {
 		executionTimes = append(executionTimes, time.Now().Unix())

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -75,18 +75,18 @@ func TestStartImmediately(t *testing.T) {
 func TestAt(t *testing.T) {
 	s := NewScheduler(time.UTC)
 
-	// Schedule to run in next minute
+	// Schedule to run in next 2 seconds
 	now := time.Now().UTC()
 	dayJobDone := make(chan bool, 1)
 
 	// Schedule every day At
-	startAt := fmt.Sprintf("%02d:%02d", now.Hour(), now.Add(time.Minute).Minute())
+	startAt := fmt.Sprintf("%02d:%02d:%02d", now.Hour(), now.Minute(), now.Add(time.Second*2).Second())
 	dayJob, _ := s.Every(1).Day().At(startAt).Do(func() {
 		dayJobDone <- true
 	})
 
 	// Expected start time
-	expectedStartTime := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Add(time.Minute).Minute(), 0, 0, time.UTC)
+	expectedStartTime := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), now.Add(time.Second*2).Second(), 0, time.UTC)
 	nextRun := dayJob.NextScheduledTime()
 	assert.Equal(t, expectedStartTime, nextRun)
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -30,7 +30,7 @@ func TestExecutionSeconds(t *testing.T) {
 	sched := NewScheduler(time.UTC)
 	jobDone := make(chan bool)
 	executionTimes := make([]int64, 0, 2)
-	numberOfIterations := 2
+	numberOfIterations := 20
 
 	sched.Every(2).Seconds().Do(func() {
 		executionTimes = append(executionTimes, time.Now().Unix())

--- a/timeHelper.go
+++ b/timeHelper.go
@@ -3,7 +3,8 @@ package gocron
 import "time"
 
 type timeHelper interface {
-	Now() time.Time
+	Now(*time.Location) time.Time
+	NowRoundedDownToSeconds(*time.Location) time.Time
 	Unix(int64, int64) time.Time
 	Sleep(time.Duration)
 	Date(int, time.Month, int, int, int, int, int, *time.Location) time.Time
@@ -16,8 +17,13 @@ func newTimeHelper() timeHelper {
 
 type trueTime struct{}
 
-func (t *trueTime) Now() time.Time {
-	return time.Now()
+func (t *trueTime) Now(location *time.Location) time.Time {
+	return time.Now().In(location)
+}
+
+func (t *trueTime) NowRoundedDownToSeconds(location *time.Location) time.Time {
+	n := t.Now(location)
+	return t.Date(n.Year(), n.Month(), n.Day(), n.Hour(), n.Minute(), n.Second(), 0, location)
 }
 
 func (t *trueTime) Unix(sec int64, nsec int64) time.Time {

--- a/timeHelper.go
+++ b/timeHelper.go
@@ -4,7 +4,6 @@ import "time"
 
 type timeHelper interface {
 	Now(*time.Location) time.Time
-	NowRoundedDownToSeconds(*time.Location) time.Time
 	Unix(int64, int64) time.Time
 	Sleep(time.Duration)
 	Date(int, time.Month, int, int, int, int, int, *time.Location) time.Time
@@ -18,11 +17,7 @@ func newTimeHelper() timeHelper {
 type trueTime struct{}
 
 func (t *trueTime) Now(location *time.Location) time.Time {
-	return time.Now().In(location)
-}
-
-func (t *trueTime) NowRoundedDownToSeconds(location *time.Location) time.Time {
-	n := t.Now(location)
+	n := time.Now().In(location)
 	return t.Date(n.Year(), n.Month(), n.Day(), n.Hour(), n.Minute(), n.Second(), 0, location)
 }
 


### PR DESCRIPTION
```
package main

import (
	"fmt"
	"time"

	"github.com/go-co-op/gocron"
)

func task() {
	fmt.Printf("Task time: %v\n", time.Now().UTC())
}

func main() {
	s1 := gocron.NewScheduler(time.UTC)
	s1.Every(2).Seconds().StartImmediately().Do(task)
	<-s1.Start() // starts running (blocks current thread)
}
```

Output:
```
Task time: 2020-04-10 05:13:40.606502 +0000 UTC
Task time: 2020-04-10 05:13:42.60736 +0000 UTC
Task time: 2020-04-10 05:13:44.608121 +0000 UTC
Task time: 2020-04-10 05:13:46.609026 +0000 UTC
Task time: 2020-04-10 05:13:48.606512 +0000 UTC
Task time: 2020-04-10 05:13:50.608894 +0000 UTC
Task time: 2020-04-10 05:13:52.606553 +0000 UTC
Task time: 2020-04-10 05:13:54.608598 +0000 UTC
Task time: 2020-04-10 05:13:56.606573 +0000 UTC
Task time: 2020-04-10 05:13:58.606552 +0000 UTC
Task time: 2020-04-10 05:14:00.608368 +0000 UTC
Task time: 2020-04-10 05:14:02.606641 +0000 UTC
Task time: 2020-04-10 05:14:04.608286 +0000 UTC
Task time: 2020-04-10 05:14:06.606737 +0000 UTC
Task time: 2020-04-10 05:14:08.608174 +0000 UTC
Task time: 2020-04-10 05:14:10.608141 +0000 UTC
Task time: 2020-04-10 05:14:12.606751 +0000 UTC
Task time: 2020-04-10 05:14:14.607512 +0000 UTC
Task time: 2020-04-10 05:14:16.606776 +0000 UTC
Task time: 2020-04-10 05:14:18.607749 +0000 UTC
Task time: 2020-04-10 05:14:20.606882 +0000 UTC
Task time: 2020-04-10 05:14:22.606922 +0000 UTC
Task time: 2020-04-10 05:14:24.608243 +0000 UTC
Task time: 2020-04-10 05:14:26.608399 +0000 UTC
Task time: 2020-04-10 05:14:28.607878 +0000 UTC
Task time: 2020-04-10 05:14:30.606958 +0000 UTC
Task time: 2020-04-10 05:14:32.607995 +0000 UTC
Task time: 2020-04-10 05:14:34.60762 +0000 UTC
Task time: 2020-04-10 05:14:36.607508 +0000 UTC
Task time: 2020-04-10 05:14:38.60877 +0000 UTC
Task time: 2020-04-10 05:14:40.609291 +0000 UTC
Task time: 2020-04-10 05:14:42.607145 +0000 UTC
Task time: 2020-04-10 05:14:44.608426 +0000 UTC
```

Closes #20 
