### PR TITLE
Fix removeByCondition get "slice bounds out of range"

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -213,9 +213,11 @@ func (s *Scheduler) RemoveByReference(j *Job) {
 }
 
 func (s *Scheduler) removeByCondition(shouldRemove func(*Job) bool) {
-	for i, job := range s.jobs {
-		if shouldRemove(job) {
+	for i := 0; i < len(s.jobs); {
+		if shouldRemove(s.jobs[i]) {
 			s.jobs = removeAtIndex(s.jobs, i)
+		} else {
+			i++
 		}
 	}
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -213,13 +213,13 @@ func (s *Scheduler) RemoveByReference(j *Job) {
 }
 
 func (s *Scheduler) removeByCondition(shouldRemove func(*Job) bool) {
-	for i := 0; i < len(s.jobs); {
-		if shouldRemove(s.jobs[i]) {
-			s.jobs = removeAtIndex(s.jobs, i)
-		} else {
-			i++
+	retainedJobs := make([]*Job, 0)
+	for _, job := range s.jobs {
+		if !shouldRemove(job) {
+			retainedJobs = append(retainedJobs, job)
 		}
 	}
+	s.jobs = retainedJobs
 }
 
 // RemoveJobByTag will Remove Jobs by Tag

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -369,11 +369,12 @@ func TestRemove(t *testing.T) {
 	scheduler := NewScheduler(time.UTC)
 	scheduler.Every(1).Minute().Do(task)
 	scheduler.Every(1).Minute().Do(taskWithParams, 1, "hello")
+	scheduler.Every(1).Minute().Do(task)
 
-	assert.Equal(t, 2, scheduler.Len(), "Incorrect number of jobs")
+	assert.Equal(t, 3, scheduler.Len(), "Incorrect number of jobs")
 
 	scheduler.Remove(task)
-	assert.Equal(t, 1, scheduler.Len(), "Incorrect number of jobs after removing 1 job")
+	assert.Equal(t, 1, scheduler.Len(), "Incorrect number of jobs after removing 2 job")
 
 	scheduler.Remove(task)
 	assert.Equal(t, 1, scheduler.Len(), "Incorrect number of jobs after removing non-existent job")


### PR DESCRIPTION
### What does this do?
Fix removeByCondition get "slice bounds out of range".

### Which issue(s) does this PR fix/relate to?
Resolves #45 


### List any changes that modify/break current functionality
1. Adding corner case on TestRemove unit test in `schedule_test.go`
2. Changing `range` loop to traditional iteration loop on `removeByCondition` in `schedule.go` to fix slice bounds out of range.

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
