### PR TITLE
Parse the At() time with time.Parse()

### DIFF
--- a/gocron_test.go
+++ b/gocron_test.go
@@ -26,7 +26,7 @@ func TestFormatTime(t *testing.T) {
 		},
 		{
 			name:     "normal_with_second",
-			args:     "6:18:01",
+			args:     "06:18:01",
 			wantHour: 6,
 			wantMin:  18,
 			wantSec:  1,
@@ -77,7 +77,7 @@ func TestFormatTime(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotHour, gotMin, gotSec, err := formatTime(tt.args)
+			gotHour, gotMin, gotSec, err := parseTime(tt.args)
 			if tt.wantErr {
 				assert.NotEqual(t, nil, err, tt.args)
 				return

--- a/scheduler.go
+++ b/scheduler.go
@@ -327,7 +327,7 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 // At schedules the Job at a specific time of day in the form "HH:MM:SS" or "HH:MM"
 func (s *Scheduler) At(t string) *Scheduler {
 	j := s.getCurrentJob()
-	hour, min, sec, err := formatTime(t)
+	hour, min, sec, err := parseTime(t)
 	if err != nil {
 		j.err = ErrTimeFormat
 		return s


### PR DESCRIPTION
### What does this do?
Parse the At() time with time.Parse() instead of `Atoi`

### Which issue(s) does this PR fix/relate to?
#14 


### List any changes that modify/break current functionality
One small change is before `6:40` would have been considered valid, but now, it has to be `06:40`.

### Have you included tests for your changes?
Existing tests suffice 

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
