### PR TITLE
Bugfix: Make sure Do() does not override the nextRun time when StartAt() is used

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -316,8 +316,10 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 			}
 		}
 
-		if err := s.scheduleNextRun(j); err != nil {
-			return nil, err
+		if j.nextRun == s.time.Unix(0, 0) {
+			if err := s.scheduleNextRun(j); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -546,3 +546,27 @@ func TestMonths(t *testing.T) {
 		nextRun,
 	)
 }
+
+func TestScheduler_StartAt(t *testing.T) {
+	scheduler := NewScheduler(time.Local)
+	now := time.Now()
+
+	// With StartAt
+	job, _ := scheduler.Every(3).Seconds().StartAt(now.Add(time.Second * 5)).Do(func() {})
+	_, nextRun := scheduler.NextRun()
+	assert.Equal(
+		t,
+		now.Add(time.Second*5),
+		nextRun,
+	)
+	scheduler.Remove(job)
+
+	// Without StartAt
+	scheduler.Every(3).Seconds().Do(func() {})
+	_, nextRun = scheduler.NextRun()
+	assert.Equal(
+		t,
+		now.Add(time.Second*3).Second(),
+		nextRun.Second(),
+	)
+}


### PR DESCRIPTION
### What does this do?
Make sure Do() does not override the nextRun time when StartAt() is used

### Which issue(s) does this PR fix/relate to?
Fixes #35 

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Yes
