### PR TITLE
refact: rewriting scheduler logic

### DIFF
--- a/job.go
+++ b/job.go
@@ -7,21 +7,21 @@ import (
 
 // Job struct stores the information necessary to run a Job
 type Job struct {
-	interval             uint64                   // pause interval * unit between runs
-	unit                 timeUnit                 // time units, ,e.g. 'minutes', 'hours'...
-	periodDuration       time.Duration            // interval * unit
-	startImmediatelyFlag bool                     // if the Job should run upon scheduler start
-	jobFunc              string                   // the Job jobFunc to run, func[jobFunc]
-	atTime               time.Duration            // optional time at which this Job runs
-	err                  error                    // error related to Job
-	lastRun              time.Time                // datetime of last run
-	nextRun              time.Time                // datetime of next run
-	scheduledWeekday     *time.Weekday            // Specific day of the week to start on
-	dayOfTheMonth        int                      // Specific day of the month to run the job
-	funcs                map[string]interface{}   // Map for the function task store
-	fparams              map[string][]interface{} // Map for function and  params of function
-	lock                 bool                     // lock the Job from running at same time form multiple instances
-	tags                 []string                 // allow the user to tag Jobs with certain labels
+	interval          uint64                   // pause interval * unit between runs
+	unit              timeUnit                 // time units, ,e.g. 'minutes', 'hours'...
+	periodDuration    time.Duration            // interval * unit
+	startsImmediately bool                     // if the Job should run upon scheduler start
+	jobFunc           string                   // the Job jobFunc to run, func[jobFunc]
+	atTime            time.Duration            // optional time at which this Job runs
+	err               error                    // error related to Job
+	lastRun           time.Time                // datetime of last run
+	nextRun           time.Time                // datetime of next run
+	scheduledWeekday  *time.Weekday            // Specific day of the week to start on
+	dayOfTheMonth     int                      // Specific day of the month to run the job
+	funcs             map[string]interface{}   // Map for the function task store
+	fparams           map[string][]interface{} // Map for function and  params of function
+	lock              bool                     // lock the Job from running at same time form multiple instances
+	tags              []string                 // allow the user to tag Jobs with certain labels
 }
 
 // NewJob creates a new Job with the provided interval

--- a/job.go
+++ b/job.go
@@ -87,9 +87,9 @@ func (j *Job) ScheduledAtTime() string {
 
 // Weekday returns which day of the week the Job will run on and
 // will return an error if the Job is not scheduled weekly
-func (j *Job) Weekday() (*time.Weekday, error) {
+func (j *Job) Weekday() (time.Weekday, error) {
 	if j.scheduledWeekday == nil {
-		return nil, ErrNotScheduledWeekday
+		return time.Sunday, ErrNotScheduledWeekday
 	}
-	return j.scheduledWeekday, nil
+	return *j.scheduledWeekday, nil
 }

--- a/job.go
+++ b/job.go
@@ -9,7 +9,6 @@ import (
 type Job struct {
 	interval          uint64                   // pause interval * unit between runs
 	unit              timeUnit                 // time units, ,e.g. 'minutes', 'hours'...
-	periodDuration    time.Duration            // interval * unit
 	startsImmediately bool                     // if the Job should run upon scheduler start
 	jobFunc           string                   // the Job jobFunc to run, func[jobFunc]
 	atTime            time.Duration            // optional time at which this Job runs
@@ -74,28 +73,6 @@ func (j *Job) Untag(t string) {
 // Tags returns the tags attached to the Job
 func (j *Job) Tags() []string {
 	return j.tags
-}
-
-func (j *Job) setPeriodDuration() error {
-	interval := time.Duration(j.interval)
-
-	switch j.unit {
-	case seconds:
-		j.periodDuration = interval * time.Second
-	case minutes:
-		j.periodDuration = interval * time.Minute
-	case hours:
-		j.periodDuration = interval * time.Hour
-	case days:
-		j.periodDuration = interval * time.Hour * 24
-	case weeks:
-		j.periodDuration = interval * time.Hour * 24 * 7
-	case months:
-		// periodDuration doesn't apply here
-	default:
-		return ErrPeriodNotSpecified
-	}
-	return nil
 }
 
 // ScheduledTime returns the time of the Job's next scheduled run

--- a/job.go
+++ b/job.go
@@ -110,9 +110,9 @@ func (j *Job) ScheduledAtTime() string {
 
 // Weekday returns which day of the week the Job will run on and
 // will return an error if the Job is not scheduled weekly
-func (j *Job) Weekday() (time.Weekday, error) {
-	if j.unit == weeks {
-		return *j.scheduledWeekday, nil
+func (j *Job) Weekday() (*time.Weekday, error) {
+	if j.scheduledWeekday == nil {
+		return nil, ErrNotScheduledWeekday
 	}
-	return time.Sunday, ErrNotScheduledWeekday
+	return j.scheduledWeekday, nil
 }

--- a/job.go
+++ b/job.go
@@ -41,7 +41,7 @@ func (j *Job) run() {
 	callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
 }
 
-func (j Job) NeverRan() bool {
+func (j Job) neverRan() bool {
 	return j.lastRun.IsZero()
 }
 

--- a/job_test.go
+++ b/job_test.go
@@ -53,29 +53,3 @@ func TestGetWeekday(t *testing.T) {
 		})
 	}
 }
-
-func TestSetPeriodDuration(t *testing.T) {
-
-	testCases := []struct {
-		desc             string
-		job              *Job
-		expectedDuration time.Duration
-		expectedError    error
-	}{
-		{"seconds", &Job{interval: 1, unit: seconds}, time.Duration(1) * time.Second, nil},
-		{"minutes", &Job{interval: 1, unit: minutes}, time.Duration(1) * time.Minute, nil},
-		{"hours", &Job{interval: 1, unit: hours}, time.Duration(1) * time.Hour, nil},
-		{"days", &Job{interval: 1, unit: days}, time.Duration(1) * time.Hour * 24, nil},
-		{"weeks", &Job{interval: 1, unit: weeks}, time.Duration(1) * time.Hour * 24 * 7, nil},
-		{"none", &Job{interval: 1}, 0, ErrPeriodNotSpecified},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			err := tc.job.setPeriodDuration()
-			assert.Equal(t, tc.expectedError, err)
-			assert.Equal(t, tc.expectedDuration, tc.job.periodDuration)
-		})
-	}
-
-}

--- a/job_test.go
+++ b/job_test.go
@@ -27,17 +27,18 @@ func TestGetScheduledTime(t *testing.T) {
 
 func TestGetWeekday(t *testing.T) {
 	s := NewScheduler(time.UTC)
-	weedayJob, _ := s.Every(1).Weekday(time.Wednesday).Do(task)
+	wednesday := time.Wednesday
+	weedayJob, _ := s.Every(1).Weekday(wednesday).Do(task)
 	nonWeekdayJob, _ := s.Every(1).Minute().Do(task)
 
 	testCases := []struct {
 		desc            string
 		job             *Job
-		expectedWeekday time.Weekday
+		expectedWeekday *time.Weekday
 		expectedError   error
 	}{
-		{"success", weedayJob, time.Wednesday, nil},
-		{"fail - not set for weekday", nonWeekdayJob, time.Sunday, ErrNotScheduledWeekday},
+		{"success", weedayJob, &wednesday, nil},
+		{"fail - not set for weekday", nonWeekdayJob, nil, ErrNotScheduledWeekday},
 	}
 
 	for _, tc := range testCases {
@@ -46,10 +47,9 @@ func TestGetWeekday(t *testing.T) {
 			if tc.expectedError != nil {
 				assert.Error(t, tc.expectedError, err)
 			} else {
+				assert.Equal(t, tc.expectedWeekday, weekday)
 				assert.Nil(t, err)
 			}
-
-			assert.Equal(t, tc.expectedWeekday, weekday)
 		})
 	}
 }

--- a/job_test.go
+++ b/job_test.go
@@ -34,11 +34,11 @@ func TestGetWeekday(t *testing.T) {
 	testCases := []struct {
 		desc            string
 		job             *Job
-		expectedWeekday *time.Weekday
+		expectedWeekday time.Weekday
 		expectedError   error
 	}{
-		{"success", weedayJob, &wednesday, nil},
-		{"fail - not set for weekday", nonWeekdayJob, nil, ErrNotScheduledWeekday},
+		{"success", weedayJob, wednesday, nil},
+		{"fail - not set for weekday", nonWeekdayJob, time.Sunday, ErrNotScheduledWeekday},
 	}
 
 	for _, tc := range testCases {

--- a/scheduler.go
+++ b/scheduler.go
@@ -90,7 +90,7 @@ func (s *Scheduler) scheduleNextRun(j *Job) error {
 	now := s.time.Now(s.loc)
 
 	var delta time.Time
-	if j.NeverRan() {
+	if j.neverRan() {
 		if !j.nextRun.IsZero() { // scheduled for future run, wait to run at least once
 			return nil
 		}
@@ -126,7 +126,7 @@ func (s *Scheduler) scheduleNextRun(j *Job) error {
 
 func (s *Scheduler) calculateWeekday(now time.Time, j *Job) int {
 	remainingDaysToWeekday := remainingDaysToWeekday(now.Weekday(), *j.scheduledWeekday)
-	if j.NeverRan() || j.startImmediatelyFlag {
+	if j.neverRan() || j.startImmediatelyFlag {
 		if j.startImmediatelyFlag {
 			j.startImmediatelyFlag = false
 		}
@@ -400,7 +400,7 @@ func (s *Scheduler) StartImmediately() *Scheduler {
 
 // shouldRun returns true if the Job should be run now
 func (s *Scheduler) shouldRun(j *Job) bool {
-	if j.NeverRan() && j.startImmediatelyFlag {
+	if j.neverRan() && j.startImmediatelyFlag {
 		return true
 	}
 	return s.time.Now(s.loc).Unix() >= j.nextRun.Unix()

--- a/scheduler.go
+++ b/scheduler.go
@@ -101,13 +101,13 @@ func (s *Scheduler) scheduleNextRun(j *Job) error {
 
 	switch j.unit {
 	case seconds, minutes, hours:
-		if j.neverRan() && j.atTime != 0 && s.shouldRunToday(delta, j) { // ugly. in order to avoid this we could prohibit setting .At() and allowing only .StartAt() when dealing with Duration types
-			j.nextRun = s.roundToMidnight(delta.Add(j.periodDuration)).Add(j.atTime)
+		if j.neverRan() && j.atTime != 0 && s.shouldRunAt(now, j) { // ugly. in order to avoid this we could prohibit setting .At() and allowing only .StartAt() when dealing with Duration types
+			j.nextRun = s.roundToMidnight(delta).Add(j.atTime)
 			return nil
 		}
 		j.nextRun = delta.Add(j.periodDuration)
 	case days:
-		if s.shouldRunToday(now, j) {
+		if s.shouldRunAt(now, j) {
 			j.nextRun = s.roundToMidnight(delta).Add(j.atTime)
 			return nil
 		}
@@ -164,7 +164,7 @@ func (s *Scheduler) calculateFirstWeekday(now time.Time, daysToWeekday int, j *J
 	return 7
 }
 
-func (s *Scheduler) shouldRunToday(now time.Time, job *Job) bool {
+func (s *Scheduler) shouldRunAt(now time.Time, job *Job) bool {
 	atTime := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, s.loc).Add(job.atTime)
 	return now.Before(atTime)
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -424,7 +424,6 @@ func (s *Scheduler) StartAt(t time.Time) *Scheduler {
 // StartImmediately sets the Jobs next run as soon as the scheduler starts
 func (s *Scheduler) StartImmediately() *Scheduler {
 	job := s.getCurrentJob()
-	//job.nextRun = s.time.Now(s.loc)
 	job.startsImmediately = true
 	return s
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -27,7 +27,7 @@ func NewScheduler(loc *time.Location) *Scheduler {
 		loc:      loc,
 		running:  false,
 		stopChan: make(chan struct{}),
-		time:     newTimeWrapper(),
+		time:     &trueTime{},
 	}
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -101,7 +101,7 @@ func (s *Scheduler) scheduleNextRun(j *Job) error {
 
 	switch j.unit {
 	case seconds, minutes, hours:
-		if j.neverRan() && j.atTime != 0 { // in order to avoid this maybe we could prohibit setting .At() and allowing only .StartAt() when dealing with Duration types
+		if j.neverRan() && j.atTime != 0 && s.shouldRunToday(delta, j) { // ugly. in order to avoid this we could prohibit setting .At() and allowing only .StartAt() when dealing with Duration types
 			j.nextRun = s.roundToMidnight(delta.Add(j.periodDuration)).Add(j.atTime)
 			return nil
 		}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1024,16 +1024,37 @@ func TestScheduler_ScheduleDuration(t *testing.T) {
 			}
 			sched.scheduleAllJobs()
 
-			// should be scheduled 5 seconds from start At time
 			assert.Equal(t, startRunningTime.Add(10*time.Second), j.nextRun)
 
 			// then it ran
 			fakeTime.onNow = tick(startRunningTime, 10*time.Second)
 			sched.runAndReschedule(j)
 
-			// should be scheduled 12 seconds from start At time
 			assert.Equal(t, startRunningTime.Add(12*time.Second), j.nextRun)
 		})
+	})
+
+	t.Run("2 seconds starting at 10 seconds in the past should start immediately", func(t *testing.T) {
+		j, err := sched.Every(2).Seconds().At("15:15:05").Do(func() {})
+		assert.Nil(t, err)
+
+		// scheduler started
+		startRunningTime := time.Date(2020, time.August, 27, 15, 15, 15, 0, time.UTC)
+		fakeTime.onNow = func(location *time.Location) time.Time {
+			return startRunningTime
+		}
+		sched.scheduleAllJobs()
+
+		expectedFirstRun := startRunningTime.Add(2 * time.Second)
+		assert.Equal(t, expectedFirstRun, j.nextRun)
+
+		// then it ran
+		fakeTime.onNow = func(location *time.Location) time.Time {
+			return expectedFirstRun
+		}
+		sched.runAndReschedule(j)
+
+		assert.Equal(t, expectedFirstRun.Add(2*time.Second), j.nextRun)
 	})
 
 	t.Run("schedule for minutes", func(t *testing.T) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1012,6 +1012,28 @@ func TestScheduler_ScheduleDuration(t *testing.T) {
 			// should be scheduled 10 seconds from start
 			assert.Equal(t, startRunningTime.Add(10*time.Second), j.nextRun)
 		})
+
+		t.Run("2 seconds starting at 10 seconds in the future", func(t *testing.T) {
+			j, err := sched.Every(2).Seconds().At("15:15:25").Do(func() {})
+			assert.Nil(t, err)
+
+			// scheduler started
+			startRunningTime := time.Date(2020, time.August, 27, 15, 15, 15, 0, time.UTC)
+			fakeTime.onNow = func(location *time.Location) time.Time {
+				return startRunningTime
+			}
+			sched.scheduleAllJobs()
+
+			// should be scheduled 5 seconds from start At time
+			assert.Equal(t, startRunningTime.Add(10*time.Second), j.nextRun)
+
+			// then it ran
+			fakeTime.onNow = tick(startRunningTime, 10*time.Second)
+			sched.runAndReschedule(j)
+
+			// should be scheduled 12 seconds from start At time
+			assert.Equal(t, startRunningTime.Add(12*time.Second), j.nextRun)
+		})
 	})
 
 	t.Run("schedule for minutes", func(t *testing.T) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -406,43 +406,6 @@ func TestScheduler_StartAt(t *testing.T) {
 	assert.Equal(t, now.Add(time.Second*3).Second(), nextRun.Second())
 }
 
-func TestAt(t *testing.T) {
-	t.Run("runAt(3 seconds in the future) should run today at current time plus 3 seconds", func(t *testing.T) {
-		// WARNING: non-deterministic test
-		s := NewScheduler(time.UTC)
-		now := time.Now().UTC()
-		scheduletime := now.Add(3 * time.Second)
-
-		// Schedule every day At
-		startAt := fmt.Sprintf("%02d:%02d:%02d", scheduletime.Hour(), scheduletime.Minute(), scheduletime.Second())
-		job, _ := s.Every(1).Day().At(startAt).Do(func() {
-
-		})
-		s.scheduleAllJobs()
-
-		// Expected start time
-		expectedStartTime := time.Date(scheduletime.Year(), scheduletime.Month(), scheduletime.Day(), now.Hour(), now.Minute(), now.Add(3*time.Second).Second(), 0, time.UTC)
-		assert.Equal(t, expectedStartTime, job.ScheduledTime())
-	})
-	t.Run("runAt(3 seconds in the past) should run tomorrow at current time minus 3 seconds", func(t *testing.T) {
-		s := NewScheduler(time.UTC)
-		now := time.Now().UTC()
-		scheduletime := now.Add(3 * (-time.Second))
-
-		// Schedule every day At
-		startAt := fmt.Sprintf("%02d:%02d:%02d", scheduletime.Hour(), scheduletime.Minute(), scheduletime.Second())
-		job, _ := s.Every(1).Day().At(startAt).Do(func() {
-
-		})
-		s.scheduleAllJobs()
-
-		// Expected start time
-		tomorrow := now.AddDate(0, 0, 1)
-		expectedStartTime := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), now.Hour(), now.Minute(), now.Add(3*(-time.Second)).Second(), 0, time.UTC)
-		assert.Equal(t, expectedStartTime, job.ScheduledTime())
-	})
-}
-
 func TestScheduler_FirstSchedule(t *testing.T) {
 	day := time.Hour * 24
 	janFirst2020 := time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -393,9 +393,6 @@ func TestScheduler_StartAt(t *testing.T) {
 	job, _ := scheduler.Every(3).Seconds().StartAt(now.Add(time.Second * 5)).Do(func() {})
 	scheduler.scheduleAllJobs()
 	_, nextRun := scheduler.NextRun()
-	t.Log("now: " + now.String())
-	t.Log("next run : " + nextRun.String())
-	t.Log("now plus 5 run : " + now.Add(time.Second*5).String())
 	assert.Equal(t, now.Add(time.Second*5), nextRun)
 	scheduler.Remove(job)
 

--- a/timeHelper.go
+++ b/timeHelper.go
@@ -6,7 +6,6 @@ type timeWrapper interface {
 	Now(*time.Location) time.Time
 	Unix(int64, int64) time.Time
 	Sleep(time.Duration)
-	Date(int, time.Month, int, int, int, int, int, *time.Location) time.Time
 	NewTicker(time.Duration) *time.Ticker
 }
 
@@ -14,11 +13,12 @@ func newTimeWrapper() timeWrapper {
 	return &trueTime{}
 }
 
-type trueTime struct{}
+type trueTime struct {
+	*time.Time
+}
 
 func (t *trueTime) Now(location *time.Location) time.Time {
-	n := time.Now().In(location)
-	return t.Date(n.Year(), n.Month(), n.Day(), n.Hour(), n.Minute(), n.Second(), 0, location)
+	return time.Now().In(location)
 }
 
 func (t *trueTime) Unix(sec int64, nsec int64) time.Time {
@@ -27,10 +27,6 @@ func (t *trueTime) Unix(sec int64, nsec int64) time.Time {
 
 func (t *trueTime) Sleep(d time.Duration) {
 	time.Sleep(d)
-}
-
-func (t *trueTime) Date(year int, month time.Month, day, hour, min, sec, nsec int, loc *time.Location) time.Time {
-	return time.Date(year, month, day, hour, min, sec, nsec, loc)
 }
 
 func (t *trueTime) NewTicker(d time.Duration) *time.Ticker {

--- a/timeHelper.go
+++ b/timeHelper.go
@@ -9,13 +9,7 @@ type timeWrapper interface {
 	NewTicker(time.Duration) *time.Ticker
 }
 
-func newTimeWrapper() timeWrapper {
-	return &trueTime{}
-}
-
-type trueTime struct {
-	*time.Time
-}
+type trueTime struct{}
 
 func (t *trueTime) Now(location *time.Location) time.Time {
 	return time.Now().In(location)


### PR DESCRIPTION
### What does this do?
Time scheduling was spread between job registration and actual schedule calculation, which was confusing and made testing difficult. As a matter of fact, our weekdays logic wasn't working for some edge cases and we probably had some bugs out on .Month() calculation too, although I didn't check it explicitly.

This PR rewrites our next-run scheduling logic and cover it with different tests use cases, taking in consideration weekday schedules, weekdays schedules starting immediately and exact-time schedules.

Sorry for it being big. Most of the new lines are tests cases.
 
### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
This might fix #52. I cannot actually say this fixes it since I was not able to reproduce it, but nevertheless this PR fixes weekday logic.

### List any changes that modify/break current functionality

None

### Have you included tests for your changes?

Lots of, but might have missed something. Please bring it up if you can think of anything.
