### PR TITLE
fix: scheduler schedules jobs registration when already running

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -392,6 +392,7 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 	j.fparams[fname] = params
 	j.jobFunc = fname
 
+	// we should not schedule if not running since we cant foresee how long it will take for the scheduler to start
 	if s.running {
 		s.scheduleNextRun(j)
 	}

--- a/scheduler.go
+++ b/scheduler.go
@@ -392,6 +392,10 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 	j.fparams[fname] = params
 	j.jobFunc = fname
 
+	if s.running {
+		s.scheduleNextRun(j)
+	}
+
 	return j, nil
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -631,3 +631,21 @@ func (f fakeTime) Sleep(duration time.Duration) {
 func (f fakeTime) NewTicker(duration time.Duration) *time.Ticker {
 	panic("implement me")
 }
+
+func TestScheduler_Do(t *testing.T) {
+	t.Run("adding a new job before scheduler starts does not schedule job", func(t *testing.T) { // we should not schedule because we cannot guarantee how long it will take for the scheduler to start
+		s := NewScheduler(time.UTC)
+		s.running = false
+		job, err := s.Every(1).Second().Do(func() {})
+		assert.Equal(t, nil, err)
+		assert.True(t, job.nextRun.IsZero())
+	})
+
+	t.Run("adding a new job when scheduler is running schedules job", func(t *testing.T) {
+		s := NewScheduler(time.UTC)
+		s.running = true
+		job, err := s.Every(1).Second().Do(func() {})
+		assert.Equal(t, nil, err)
+		assert.False(t, job.nextRun.IsZero())
+	})
+}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -633,7 +633,7 @@ func (f fakeTime) NewTicker(duration time.Duration) *time.Ticker {
 }
 
 func TestScheduler_Do(t *testing.T) {
-	t.Run("adding a new job before scheduler starts does not schedule job", func(t *testing.T) { // we should not schedule because we cannot guarantee how long it will take for the scheduler to start
+	t.Run("adding a new job before scheduler starts does not schedule job", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		s.running = false
 		job, err := s.Every(1).Second().Do(func() {})


### PR DESCRIPTION
### What does this do?
scheduler schedules jobs registration when already running

### Which issue(s) does this PR fix/relate to?
#60 #58 
