### PR TITLE
Add option to limit maximum concurrent jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ Examples:
 package main
 
 import (
-	"fmt"
-	"time"
+    "fmt"
+    "time"
+    "runtime"
 
-	"github.com/go-co-op/gocron"
+    "github.com/go-co-op/gocron"
 )
 
 func task() {
@@ -36,6 +37,10 @@ func taskWithParams(a int, b string) {
 func main() {
     // defines a new scheduler that schedules and runs jobs
     s1 := gocron.NewScheduler(time.UTC)
+
+    // we have very intensive jobs with flexible schedules, so limiting the
+    // maximum jobs that can run at a time
+    s1.SetMaxConcurrentJobs(runtime.NumCPU())
 
     s1.Every(3).Seconds().Do(task)
 

--- a/example_test.go
+++ b/example_test.go
@@ -23,6 +23,16 @@ func ExampleScheduler_At() {
 	s.Every(1).Monday().At("10:30:01").Do(task)
 }
 
+func ExampleScheduler_SetMaxConcurrentJobs() {
+	s := gocron.NewScheduler(time.UTC)
+	s.SetMaxConcurrentJobs(1)
+	s.Every(1).Seconds().Do(func() {
+		fmt.Println("This will run once every 5 seconds even though it is scheduled every 1 seconds because of maximum concurrency.")
+		time.Sleep(5 * time.Second)
+	})
+	s.StartBlocking()
+}
+
 func ExampleJob_ScheduledTime() {
 	s := gocron.NewScheduler(time.UTC)
 	job, _ := s.Every(1).Day().At("10:30").Do(task)

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )


### PR DESCRIPTION
### What does this do?
This feature is backwards compatible and allows limiting the maximum concurrent jobs.
It is useful when running resource intensive jobs and a precise start time is not critical.


### Which issue(s) does this PR fix/relate to?

Resolves #53


### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?

- [X] Updated `example_test.go`
- [X] Updated `README.md`

### Notes
