### PR TITLE
fix on skipping job running when job.lock enabled

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -270,7 +270,15 @@ func (s *Scheduler) run(job *Job) error {
 		}
 		key := getFunctionKey(job.jobFunc)
 
-		locker.Lock(key)
+		success, err := locker.Lock(key)
+		if err != nil {
+			return err
+		}
+		if !success {
+			job.lastRun = s.time.Now(s.loc)
+			return nil
+		}
+
 		defer locker.Unlock(key)
 	}
 


### PR DESCRIPTION
### What does this do?
If the cron has lock implementation(e.g. Redis example), once the "success" return false the job execution will be skipped.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves #50 

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
