### PR TITLE
Add a new Job method called 'LimitRunsTo'

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -88,3 +88,10 @@ func ExampleScheduler_Clear() {
 	// 3
 	// 0
 }
+
+func ExampleJob_LimitRunsTo() {
+	s := gocron.NewScheduler(time.UTC)
+	job, _ := s.Every(1).Second().Do(task)
+	job.LimitRunsTo(2)
+	s.StartAsync()
+}

--- a/scheduler.go
+++ b/scheduler.go
@@ -435,7 +435,7 @@ func (s *Scheduler) StartImmediately() *Scheduler {
 
 // shouldRun returns true if the Job should be run now
 func (s *Scheduler) shouldRun(j *Job) bool {
-	return s.time.Now(s.loc).Unix() >= j.nextRun.Unix()
+	return j.shouldRun() && s.time.Now(s.loc).Unix() >= j.nextRun.Unix()
 }
 
 // setUnit sets the unit type


### PR DESCRIPTION
### What does this do?
Exposes a new `Job` method called  `LimitRunsTo` to control how many times a job should run


### Which issue(s) does this PR fix/relate to?
Closes #24 


### List any changes that modify/break current functionality
Backward compatible 

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?

- [X] Updated `example_test.go`
- [ ] Updated `README.md`

Please suggest better function/struct/field names if required. 