### PR TITLE
set the job's last run in scheduler run()

### DIFF
--- a/gocron_test.go
+++ b/gocron_test.go
@@ -1,11 +1,12 @@
 package gocron
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestFormatTime(t *testing.T) {
+func TestParseTime(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     string

--- a/scheduler.go
+++ b/scheduler.go
@@ -287,6 +287,7 @@ func (s *Scheduler) runAndReschedule(job *Job) error {
 }
 
 func (s *Scheduler) run(job *Job) error {
+	job.lastRun = s.time.Now(s.loc)
 	go job.run()
 	return nil
 }


### PR DESCRIPTION
### What does this do?
#79 removed the setting of last run - re-adding it. Without setting the last run, https://github.com/go-co-op/gocron/blob/master/scheduler.go#L100 is always true.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #80 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
yes - updated an existing test to catch this issue

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
