### PR TITLE
Expose the Job's lastRun, nextRun and runCount 

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -96,3 +96,39 @@ func ExampleJob_LimitRunsTo() {
 	job.LimitRunsTo(2)
 	s.StartAsync()
 }
+
+func ExampleJob_LastRun() {
+	s := gocron.NewScheduler(time.UTC)
+	job, _ := s.Every(1).Second().Do(task)
+	go func() {
+		for {
+			fmt.Println("Last run", job.LastRun())
+			time.Sleep(time.Second)
+		}
+	}()
+	<-s.StartAsync()
+}
+
+func ExampleJob_NextRun() {
+	s := gocron.NewScheduler(time.UTC)
+	job, _ := s.Every(1).Second().Do(task)
+	go func() {
+		for {
+			fmt.Println("Next run", job.NextRun())
+			time.Sleep(time.Second)
+		}
+	}()
+	<-s.StartAsync()
+}
+
+func ExampleJob_RunCount() {
+	s := gocron.NewScheduler(time.UTC)
+	job, _ := s.Every(1).Second().Do(task)
+	go func() {
+		for {
+			fmt.Println("Run count", job.RunCount())
+			time.Sleep(time.Second)
+		}
+	}()
+	<-s.StartAsync()
+}

--- a/job.go
+++ b/job.go
@@ -126,15 +126,24 @@ func (j *Job) shouldRun() bool {
 
 // LastRun returns the time the job was run last
 func (j *Job) LastRun() time.Time {
-	return j.lastRun
+	j.Lock()
+	defer j.Unlock()
+	lastRun := j.lastRun
+	return lastRun
 }
 
 // NextRun returns the time the job will run next
 func (j *Job) NextRun() time.Time {
-	return j.nextRun
+	j.Lock()
+	defer j.Unlock()
+	nextRun := j.nextRun
+	return nextRun
 }
 
 // RunCount returns the number of time the job ran so far
 func (j *Job) RunCount() int {
-	return j.runCount
+	j.Lock()
+	defer j.Unlock()
+	runCount := j.runCount
+	return runCount
 }

--- a/job.go
+++ b/job.go
@@ -22,10 +22,10 @@ type Job struct {
 	scheduledWeekday  *time.Weekday            // Specific day of the week to start on
 	dayOfTheMonth     int                      // Specific day of the month to run the job
 	funcs             map[string]interface{}   // Map for the function task store
-	fparams           map[string][]interface{} // Map for function and  params of function
+	fparams           map[string][]interface{} // Map for function and params of function
 	tags              []string                 // allow the user to tag Jobs with certain labels
 	runConfig         runConfig                // configuration for how many times to run the job
-	runCount          int                      // number of time the job ran
+	runCount          int                      // number of times the job ran
 }
 
 type runConfig struct {
@@ -122,4 +122,19 @@ func (j *Job) LimitRunsTo(n int) {
 // based on the runConfig
 func (j *Job) shouldRun() bool {
 	return !j.runConfig.finiteRuns || j.runCount < j.runConfig.maxRuns
+}
+
+// LastRun returns the time the job was run last
+func (j *Job) LastRun() time.Time {
+	return j.lastRun
+}
+
+// NextRun returns the time the job will run next
+func (j *Job) NextRun() time.Time {
+	return j.nextRun
+}
+
+// RunCount returns the number of time the job ran so far
+func (j *Job) RunCount() int {
+	return j.runCount
 }

--- a/job_test.go
+++ b/job_test.go
@@ -121,6 +121,7 @@ func TestJob_CommonExports(t *testing.T) {
 	j.runCount = 5
 	assert.Equal(t, 5, j.RunCount())
 
-	j.run()
-	assert.False(t, j.LastRun().IsZero())
+	lastRun := time.Now()
+	j.lastRun = lastRun
+	assert.Equal(t, lastRun, j.LastRun())
 }

--- a/job_test.go
+++ b/job_test.go
@@ -107,3 +107,20 @@ func TestJob_LimitRunsTo(t *testing.T) {
 	j.run()
 	assert.Equal(t, j.shouldRun(), false, "Not expecting it to run again")
 }
+
+func TestJob_CommonExports(t *testing.T) {
+	s := NewScheduler(time.Local)
+	j, _ := s.Every(1).Second().Do(func() {})
+	assert.Equal(t, 0, j.RunCount())
+	assert.True(t, j.LastRun().IsZero())
+	assert.True(t, j.NextRun().IsZero())
+
+	s.StartAsync()
+	assert.False(t, j.NextRun().IsZero())
+
+	j.runCount = 5
+	assert.Equal(t, 5, j.RunCount())
+
+	j.run()
+	assert.False(t, j.LastRun().IsZero())
+}


### PR DESCRIPTION
### What does this do?
Add 3 exported methods to the Job struct to expose lastRun, nextRun and runCount

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
