### PR TITLE
fix runnableJobs where subsequent jobs are never checked

### DIFF
--- a/job.go
+++ b/job.go
@@ -58,7 +58,7 @@ func (j *Job) neverRan() bool {
 	return j.lastRun.IsZero()
 }
 
-// Err returns an error if one ocurred while creating the Job
+// Err returns an error if one occurred while creating the Job
 func (j *Job) Err() error {
 	return j.err
 }
@@ -74,7 +74,7 @@ func (j *Job) Tag(t string, others ...string) {
 
 // Untag removes a tag from a Job
 func (j *Job) Untag(t string) {
-	newTags := []string{}
+	var newTags []string
 	for _, tag := range j.tags {
 		if t != tag {
 			newTags = append(newTags, tag)
@@ -118,7 +118,7 @@ func (j *Job) LimitRunsTo(n int) {
 	}
 }
 
-// shouldRun eveluates if this job should run again
+// shouldRun evaluates if this job should run again
 // based on the runConfig
 func (j *Job) shouldRun() bool {
 	return !j.runConfig.finiteRuns || j.runCount < j.runConfig.maxRuns

--- a/scheduler.go
+++ b/scheduler.go
@@ -250,8 +250,6 @@ func (s *Scheduler) runnableJobs() []*Job {
 	for _, job := range s.jobs {
 		if s.shouldRun(job) {
 			runnableJobs = append(runnableJobs, job)
-		} else {
-			continue
 		}
 	}
 	return runnableJobs

--- a/scheduler.go
+++ b/scheduler.go
@@ -251,7 +251,7 @@ func (s *Scheduler) runnableJobs() []*Job {
 		if s.shouldRun(job) {
 			runnableJobs = append(runnableJobs, job)
 		} else {
-			break
+			continue
 		}
 	}
 	return runnableJobs


### PR DESCRIPTION
### What does this do?
- fixes a bug identified where subsequent jobs are not scheduled if the first job is evaluating false. The `break` in the for loop causes the 2nd element to never be reached. It should be `continue`
- also some spelling fixes

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #85 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
👍 

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
