### PR TITLE
Fix: Handle job creation errors better

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -391,11 +391,16 @@ func (s *Scheduler) stopScheduler() {
 func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) {
 	j := s.getCurrentJob()
 	if j.err != nil {
+		// delete the job from the scheduler as this job
+		// cannot be executed
+		s.RemoveByReference(j)
 		return nil, j.err
 	}
 
 	typ := reflect.TypeOf(jobFun)
 	if typ.Kind() != reflect.Func {
+		// delete the job for the same reason as above
+		s.RemoveByReference(j)
 		return nil, ErrNotAFunction
 	}
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -846,3 +846,19 @@ func TestRunJobsWithLimit(t *testing.T) {
 	assert.Exactly(t, 1, j1Counter)
 	assert.Exactly(t, 1, j2Counter)
 }
+
+func TestErrorDuringJobCreation(t *testing.T) {
+	// error due to bad time format
+	badTime := "0:0"
+	s := NewScheduler(time.Local)
+	s.Every(1).Day().At(badTime).Do(func() {})
+	assert.Zero(t, len(s.jobs), "The job should be deleted if the time format is wrong")
+
+	// error due to the arg passed to Do() not being a function
+	s.Every(1).Second().Do(1)
+	assert.Zero(t, len(s.jobs), "The job should be deleted if the arg passed to Do() is not a function")
+
+	// positive case
+	s.Every(1).Day().Do(func() {})
+	assert.Equal(t, 1, len(s.jobs))
+}


### PR DESCRIPTION
### What does this do?
Remove the placeholder job from the scheduler while returning any error from the `Do` function

### Which issue(s) does this PR fix/relate to?
Closes #84 

### Have you included tests for your changes?
Yes