### PR TITLE
feat(remove/job): remove a particular job reference from the schedule…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ func main() {
 
     // Removing Job Based on Tag
     s2.RemoveJobByTag("tag1")
+    
+    // Remove a Job after its last execution
+    j, _ := s2.Every(1).StartAt(time.Now().Add(30*time.Second)).Do(task)
+    j.LimitRunsTo(1)
+    j.RemoveAfterLastRun()
 
     // Do jobs on specific weekday
     s2.Every(1).Monday().Do(task)

--- a/example_test.go
+++ b/example_test.go
@@ -132,3 +132,11 @@ func ExampleJob_RunCount() {
 	}()
 	<-s.StartAsync()
 }
+
+func ExampleJob_RemoveAfterLastRun() {
+	s := gocron.NewScheduler(time.UTC)
+	job, _ := s.Every(1).Second().Do(task)
+	job.LimitRunsTo(1)
+	job.RemoveAfterLastRun()
+	s.StartAsync()
+}

--- a/job.go
+++ b/job.go
@@ -31,6 +31,7 @@ type Job struct {
 type runConfig struct {
 	finiteRuns bool
 	maxRuns    int
+	removeAfterLastRun   bool
 }
 
 // NewJob creates a new Job with the provided interval
@@ -146,4 +147,11 @@ func (j *Job) RunCount() int {
 	defer j.Unlock()
 	runCount := j.runCount
 	return runCount
+}
+// RemoveAfterLastRun update the job in order to remove the job after its last exec
+func (j *Job) RemoveAfterLastRun() *Job {
+	j.Lock()
+	defer j.Unlock()
+	j.runConfig.removeAfterLastRun = true
+	return j
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -456,6 +456,12 @@ func (s *Scheduler) StartImmediately() *Scheduler {
 
 // shouldRun returns true if the Job should be run now
 func (s *Scheduler) shouldRun(j *Job) bool {
+
+	// option remove the job's in the scheduler after its last execution
+	if j.runConfig.removeAfterLastRun && (j.runConfig.maxRuns - j.runCount) == 1 {
+		s.RemoveByReference(j)
+	}
+
 	return j.shouldRun() && s.time.Now(s.loc).Unix() >= j.nextRun.Unix()
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -881,3 +881,18 @@ func TestDo(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveAfterExec(t *testing.T) {
+	s := NewScheduler(time.UTC)
+	s.StartAsync()
+
+	job, err := s.Every(1).StartAt(time.Now().Add(1*time.Second)).Do(task, s)
+	require.NoError(t, err)
+
+	job.LimitRunsTo(1)
+	job.RemoveAfterLastRun()
+
+	time.Sleep(2 * time.Second)
+
+	assert.Zero(t, len(s.Jobs()))
+}


### PR DESCRIPTION
…r after the last execution of the job

### What does this do?

With the scheduler we have the possibility to run a Job only once but when the Job has finished its execution we still have a reference in the Scheduler while it will not be used anymore this can lead to keep obsoletes scheduler Jobs references.

This PR allow the user to add a flag `RemoveAfterLastExec` in order to remove the job after the last job execution.

### Which issue(s) does this PR fix/relate to?
resolves #85


### List any changes that modify/break current functionality


### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [x] Updated `README.md`

### Notes
