### PR TITLE
add mutex to scheduler location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ vet:
 	@go vet $(GO_FLAGS) $(GO_PKGS)
 
 test:
-	@go test -race $(GO_FLAGS) -count=1 $(GO_PKGS)
+	@go test -race -v $(GO_FLAGS) -count=1 $(GO_PKGS)

--- a/example_test.go
+++ b/example_test.go
@@ -11,6 +11,27 @@ var task = func() {
 	fmt.Println("I am a task")
 }
 
+func ExampleScheduler_Location() {
+	s := gocron.NewScheduler(time.UTC)
+	fmt.Println(s.Location())
+	// Output: UTC
+}
+
+func ExampleScheduler_ChangeLocation() {
+	s := gocron.NewScheduler(time.UTC)
+	fmt.Println(s.Location())
+
+	location, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		panic(err)
+	}
+	s.ChangeLocation(location)
+	fmt.Println(s.Location())
+	// Output:
+	// UTC
+	// America/Los_Angeles
+}
+
 func ExampleScheduler_StartBlocking() {
 	s := gocron.NewScheduler(time.UTC)
 	_, _ = s.Every(3).Seconds().Do(task)
@@ -41,13 +62,6 @@ func ExampleScheduler_At() {
 	s := gocron.NewScheduler(time.UTC)
 	_, _ = s.Every(1).Day().At("10:30").Do(task)
 	_, _ = s.Every(1).Monday().At("10:30:01").Do(task)
-}
-
-func ExampleJob_ScheduledTime() {
-	s := gocron.NewScheduler(time.UTC)
-	job, _ := s.Every(1).Day().At("10:30").Do(task)
-	fmt.Println(job.ScheduledAtTime())
-	// Output: 10:30
 }
 
 func ExampleScheduler_RemoveJobByTag() {
@@ -81,6 +95,13 @@ func ExampleScheduler_Clear() {
 	// Output:
 	// 3
 	// 0
+}
+
+func ExampleJob_ScheduledTime() {
+	s := gocron.NewScheduler(time.UTC)
+	job, _ := s.Every(1).Day().At("10:30").Do(task)
+	fmt.Println(job.ScheduledAtTime())
+	// Output: 10:30
 }
 
 func ExampleJob_LimitRunsTo() {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -317,11 +317,11 @@ func TestLess(t *testing.T) {
 func TestSetLocation(t *testing.T) {
 	s := NewScheduler(time.FixedZone("UTC-8", -8*60*60))
 
-	assert.Equal(t, time.FixedZone("UTC-8", -8*60*60), s.loc)
+	assert.Equal(t, time.FixedZone("UTC-8", -8*60*60), s.Location())
 
 	s.ChangeLocation(time.UTC)
 
-	assert.Equal(t, time.UTC, s.loc)
+	assert.Equal(t, time.UTC, s.Location())
 }
 
 func TestClear(t *testing.T) {


### PR DESCRIPTION
### What does this do?

protects the scheduler location struct field with a mutex to avoid possible data races of changing the scheduler location while the scheduler is running

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
