### PR TITLE
refact: schedules jobs with time.AfterFunc()

### DIFF
--- a/job.go
+++ b/job.go
@@ -52,9 +52,8 @@ func NewJob(interval uint64) *Job {
 func (j *Job) run() {
 	j.Lock()
 	defer j.Unlock()
-	if j.shouldRun() {
-		callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
-	}
+	j.runCount++
+	go callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
 }
 
 func (j *Job) neverRan() bool {
@@ -175,12 +174,6 @@ func (j *Job) LimitRunsTo(n int) {
 	}
 }
 
-func (j *Job) setTimer(t *time.Timer) {
-	j.Lock()
-	defer j.Unlock()
-	j.timer = t
-}
-
 // shouldRun evaluates if this job should run again
 // based on the runConfig
 func (j *Job) shouldRun() bool {
@@ -199,7 +192,6 @@ func (j *Job) LastRun() time.Time {
 func (j *Job) setLastRun(t time.Time) {
 	j.Lock()
 	defer j.Unlock()
-	j.runCount++
 	j.lastRun = t
 }
 

--- a/job.go
+++ b/job.go
@@ -26,6 +26,7 @@ type Job struct {
 	tags              []string                 // allow the user to tag Jobs with certain labels
 	runConfig         runConfig                // configuration for how many times to run the job
 	runCount          int                      // number of times the job ran
+	Timer             *time.Timer
 }
 
 type runConfig struct {
@@ -51,8 +52,8 @@ func NewJob(interval uint64) *Job {
 func (j *Job) run() {
 	j.Lock()
 	defer j.Unlock()
-	callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
 	j.runCount++
+	go callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
 }
 
 func (j *Job) neverRan() bool {

--- a/job.go
+++ b/job.go
@@ -52,8 +52,9 @@ func NewJob(interval uint64) *Job {
 func (j *Job) run() {
 	j.Lock()
 	defer j.Unlock()
-	j.runCount++
-	go callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
+	if j.shouldRun() {
+		callJobFuncWithParams(j.funcs[j.jobFunc], j.fparams[j.jobFunc])
+	}
 }
 
 func (j *Job) neverRan() bool {
@@ -174,6 +175,12 @@ func (j *Job) LimitRunsTo(n int) {
 	}
 }
 
+func (j *Job) setTimer(t *time.Timer) {
+	j.Lock()
+	defer j.Unlock()
+	j.timer = t
+}
+
 // shouldRun evaluates if this job should run again
 // based on the runConfig
 func (j *Job) shouldRun() bool {
@@ -192,6 +199,7 @@ func (j *Job) LastRun() time.Time {
 func (j *Job) setLastRun(t time.Time) {
 	j.Lock()
 	defer j.Unlock()
+	j.runCount++
 	j.lastRun = t
 }
 

--- a/job.go
+++ b/job.go
@@ -74,6 +74,18 @@ func (j *Job) setStartsImmediately(b bool) {
 	j.startsImmediately = b
 }
 
+func (j *Job) getTimer() *time.Timer {
+	j.RLock()
+	defer j.RUnlock()
+	return j.timer
+}
+
+func (j *Job) setTimer(t *time.Timer) {
+	j.Lock()
+	defer j.Unlock()
+	j.timer = t
+}
+
 func (j *Job) getAtTime() time.Duration {
 	j.RLock()
 	defer j.RUnlock()

--- a/job.go
+++ b/job.go
@@ -26,7 +26,7 @@ type Job struct {
 	tags              []string                 // allow the user to tag Jobs with certain labels
 	runConfig         runConfig                // configuration for how many times to run the job
 	runCount          int                      // number of times the job ran
-	Timer             *time.Timer
+	timer             *time.Timer
 }
 
 type runConfig struct {

--- a/scheduler.go
+++ b/scheduler.go
@@ -309,9 +309,10 @@ func (s *Scheduler) Every(interval uint64) *Scheduler {
 }
 
 func (s *Scheduler) run(job *Job) {
-	if !s.running {
+	if !s.IsRunning() {
 		return
 	}
+
 	job.setLastRun(s.now())
 	job.run()
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -145,10 +145,10 @@ func (s *Scheduler) scheduleNextRun(job *Job) {
 
 	durationToNextRun := s.durationToNextRun(lastRun, job)
 	job.setNextRun(lastRun.Add(durationToNextRun))
-	job.timer = time.AfterFunc(durationToNextRun, func() {
+	job.setTimer(time.AfterFunc(durationToNextRun, func() {
 		s.run(job)
 		s.scheduleNextRun(job)
-	})
+	}))
 }
 
 func (s *Scheduler) durationToNextRun(t time.Time, job *Job) time.Duration {

--- a/scheduler.go
+++ b/scheduler.go
@@ -133,7 +133,7 @@ func (s *Scheduler) Location() *time.Location {
 // scheduleNextRun Compute the instant when this Job should run next
 func (s *Scheduler) scheduleNextRun(job *Job) {
 	now := s.now()
-	lastRun := job.lastRun
+	lastRun := job.LastRun()
 
 	// job can be scheduled with .StartAt()
 	if job.neverRan() {

--- a/scheduler.go
+++ b/scheduler.go
@@ -313,7 +313,7 @@ func (s *Scheduler) run(job *Job) {
 		return
 	}
 	job.setLastRun(s.now())
-	go job.run()
+	job.run()
 }
 
 // RunAll run all Jobs regardless if they are scheduled to run or not

--- a/scheduler.go
+++ b/scheduler.go
@@ -31,7 +31,7 @@ func NewScheduler(loc *time.Location) *Scheduler {
 		jobs:     make([]*Job, 0),
 		location: loc,
 		running:  false,
-		stopChan: make(chan struct{}),
+		stopChan: make(chan struct{}, 1),
 		time:     &trueTime{},
 	}
 }
@@ -46,24 +46,30 @@ func (s *Scheduler) StartAsync() chan struct{} {
 	if s.IsRunning() {
 		return s.stopChan
 	}
-	s.setRunning(true)
-
-	s.scheduleAllJobs()
-	ticker := s.time.NewTicker(1 * time.Second)
-	go func() {
-		for {
-			select {
-			case <-ticker.C:
-				s.RunPending()
-			case <-s.stopChan:
-				ticker.Stop()
-				s.setRunning(false)
-				return
-			}
-		}
-	}()
-
+	s.start()
 	return s.stopChan
+}
+
+//start runs each job and schedules it's next run
+func (s *Scheduler) start() {
+	s.setRunning(true)
+	s.runJobs()
+}
+
+func (s *Scheduler) runJobs() {
+	for _, j := range s.Jobs() {
+		if j.getStartsImmediately() {
+			s.run(j)
+			j.setStartsImmediately(false)
+		}
+		if !j.shouldRun() {
+			if j.getRemoveAfterLastRun() { // TODO: this method seems unnecessary as we could always remove after the run cout has expired. Maybe remove this in the future?
+				s.RemoveByReference(j)
+			}
+			continue
+		}
+		s.scheduleNextRun(j)
+	}
 }
 
 func (s *Scheduler) setRunning(b bool) {
@@ -126,41 +132,41 @@ func (s *Scheduler) Location() *time.Location {
 
 // scheduleNextRun Compute the instant when this Job should run next
 func (s *Scheduler) scheduleNextRun(job *Job) {
-	now := s.time.Now(s.Location())
+	now := s.now()
+	lastRun := job.lastRun
 
+	// job can be scheduled with .StartAt()
 	if job.neverRan() {
+		// TODO check: if job already scheduled next run.
 		if !job.NextRun().IsZero() {
 			return // scheduled for future run and should skip scheduling
 		}
-		// default is for jobs to start immediately unless scheduled at a specific time or day
-		if job.getStartsImmediately() {
-			job.setNextRun(now)
-			return
-		}
+		lastRun = now
 	}
 
-	job.setLastRun(now)
-
-	durationToNextRun := s.durationToNextRun(job)
-	job.setNextRun(job.LastRun().Add(durationToNextRun))
+	durationToNextRun := s.durationToNextRun(lastRun, job)
+	job.setNextRun(lastRun.Add(durationToNextRun))
+	job.Timer = time.AfterFunc(durationToNextRun, func() {
+		s.run(job)
+		s.scheduleNextRun(job)
+	})
 }
 
-func (s *Scheduler) durationToNextRun(job *Job) time.Duration {
-	lastRun := job.LastRun()
+func (s *Scheduler) durationToNextRun(t time.Time, job *Job) time.Duration {
 	var duration time.Duration
 	switch job.unit {
 	case seconds, minutes, hours:
 		duration = s.calculateDuration(job)
 	case days:
-		duration = s.calculateDays(job, lastRun)
+		duration = s.calculateDays(job, t)
 	case weeks:
 		if job.scheduledWeekday != nil { // weekday selected, Every().Monday(), for example
-			duration = s.calculateWeekday(job, lastRun)
+			duration = s.calculateWeekday(job, t)
 		} else {
-			duration = s.calculateWeeks(job, lastRun)
+			duration = s.calculateWeeks(job, t)
 		}
 	case months:
-		duration = s.calculateMonths(job, lastRun)
+		duration = s.calculateMonths(job, t)
 	}
 	return duration
 }
@@ -280,18 +286,6 @@ func (s *Scheduler) roundToMidnight(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, s.Location())
 }
 
-// Get the current runnable Jobs, which shouldRun is True
-func (s *Scheduler) runnableJobs() []*Job {
-	var runnableJobs []*Job
-	sort.Sort(s)
-	for _, job := range s.Jobs() {
-		if s.shouldRun(job) {
-			runnableJobs = append(runnableJobs, job)
-		}
-	}
-	return runnableJobs
-}
-
 // NextRun datetime when the next Job should run.
 func (s *Scheduler) NextRun() (*Job, time.Time) {
 	if len(s.Jobs()) <= 0 {
@@ -310,25 +304,18 @@ func (s *Scheduler) Every(interval uint64) *Scheduler {
 	return s
 }
 
-// RunPending runs all the Jobs that are scheduled to run.
-func (s *Scheduler) RunPending() {
-	for _, job := range s.runnableJobs() {
-		s.runAndReschedule(job) // we should handle this error somehow
-	}
-}
-
 func (s *Scheduler) runAndReschedule(job *Job) error {
-	if err := s.run(job); err != nil {
-		return err
-	}
+	s.run(job)
 	s.scheduleNextRun(job)
 	return nil
 }
 
-func (s *Scheduler) run(job *Job) error {
-	job.setLastRun(s.time.Now(s.Location()))
-	go job.run()
-	return nil
+func (s *Scheduler) run(job *Job) {
+	if !s.running {
+		return
+	}
+	job.setLastRun(s.now())
+	job.run()
 }
 
 // RunAll run all Jobs regardless if they are scheduled to run or not
@@ -339,10 +326,7 @@ func (s *Scheduler) RunAll() {
 // RunAllWithDelay runs all Jobs with delay seconds
 func (s *Scheduler) RunAllWithDelay(d int) {
 	for _, job := range s.Jobs() {
-		err := s.run(job)
-		if err != nil {
-			continue
-		}
+		s.run(job)
 		s.time.Sleep(time.Duration(d) * time.Second)
 	}
 }
@@ -418,11 +402,12 @@ func (s *Scheduler) Clear() {
 // Stop stops the scheduler. This is a no-op if the scheduler is already stopped .
 func (s *Scheduler) Stop() {
 	if s.IsRunning() {
-		s.stopScheduler()
+		s.stop()
 	}
 }
 
-func (s *Scheduler) stopScheduler() {
+func (s *Scheduler) stop() {
+	s.setRunning(false)
 	s.stopChan <- struct{}{}
 }
 
@@ -626,8 +611,6 @@ func (s *Scheduler) getCurrentJob() *Job {
 	return s.Jobs()[len(s.jobs)-1]
 }
 
-func (s *Scheduler) scheduleAllJobs() {
-	for _, j := range s.Jobs() {
-		s.scheduleNextRun(j)
-	}
+func (s *Scheduler) now() time.Time {
+	return s.time.Now(s.Location())
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -137,7 +137,6 @@ func (s *Scheduler) scheduleNextRun(job *Job) {
 
 	// job can be scheduled with .StartAt()
 	if job.neverRan() {
-		// TODO check: if job already scheduled next run.
 		if !job.NextRun().IsZero() {
 			return // scheduled for future run and should skip scheduling
 		}
@@ -146,7 +145,7 @@ func (s *Scheduler) scheduleNextRun(job *Job) {
 
 	durationToNextRun := s.durationToNextRun(lastRun, job)
 	job.setNextRun(lastRun.Add(durationToNextRun))
-	job.Timer = time.AfterFunc(durationToNextRun, func() {
+	job.timer = time.AfterFunc(durationToNextRun, func() {
 		s.run(job)
 		s.scheduleNextRun(job)
 	})
@@ -302,12 +301,6 @@ func (s *Scheduler) Every(interval uint64) *Scheduler {
 	job := NewJob(interval)
 	s.setJobs(append(s.Jobs(), job))
 	return s
-}
-
-func (s *Scheduler) runAndReschedule(job *Job) error {
-	s.run(job)
-	s.scheduleNextRun(job)
-	return nil
 }
 
 func (s *Scheduler) run(job *Job) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -387,6 +387,14 @@ func TestScheduler_Stop(t *testing.T) {
 		s.Stop()
 		assert.False(t, s.IsRunning())
 	})
+	t.Run("stops a running scheduler through StartAsync chan", func(t *testing.T) {
+		s := NewScheduler(time.UTC)
+		c := s.StartAsync()
+		assert.True(t, s.IsRunning())
+		close(c)
+		time.Sleep(1 * time.Millisecond) // wait for stop goroutine to catch up
+		assert.False(t, s.IsRunning())
+	})
 	t.Run("noop on stopped scheduler", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		s.Stop()
@@ -816,7 +824,7 @@ func TestScheduler_Do(t *testing.T) {
 		s.setRunning(false)
 		job, err := s.Every(1).Second().Do(func() {})
 		assert.Equal(t, nil, err)
-		assert.True(t, job.nextRun.IsZero())
+		assert.True(t, job.NextRun().IsZero())
 	})
 
 	t.Run("adding a new job when scheduler is running schedules job", func(t *testing.T) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -116,7 +116,7 @@ func TestAtFuture(t *testing.T) {
 		now := time.Now().UTC()
 
 		// Schedule to run in next minute
-		nextMinuteTime := now.Add(1 * time.Minute)
+		nextMinuteTime := now.Add(1 * time.Minute) // fixme: test fails any hour at :59
 		startAt := fmt.Sprintf("%02d:%02d:%02d", nextMinuteTime.Hour(), nextMinuteTime.Minute(), nextMinuteTime.Second())
 		var hasRan bool
 		dayJob, _ := s.Every(1).Day().At(startAt).Do(func() {


### PR DESCRIPTION
### What does this do?
Main change: scheduler now uses `time.AfterFunc` from the standard ```time``` package to schedule jobs instead of manually sorting and looping through all jobs (yes, finally!)

This brings us:

- assertion that our "run jobs" algorithm works without bugs as we're leaving this logic to a standard package
- greater flexibility in what fields we want to keep in jobs - no need to actually keep other fields like `nextRun` or even our job slice for our run logic (they may still be useful for logging or getting meta info about a job or the scheduler, so they're not removed here)
- minor performance gains as we don't sort and loop through our job array every second anymore
- increased cohesion of our scheduler package 

Unfortunately, after doing this refactor and separating the logic correctly, some tests broke, which made this pr a bit larger than what it needed to be. Fortunately, these failures actually brought minor errors to attention; I fixed them in here, so here's a list of what's different:

- calling `.Close()` without listening to the channel returned by `.StartAsync()` would freeze the application;  fixed by making `stopChan` a buffered channel: now the application doesn't freeze up anymore 
- before, the scheduler invoked each job by calling `go job.Run()`. This method not only calls the job function but also updates the run counter, which fails to remove jobs that start immediately (this passed our tests because all tests used `.At()`). This has been fixed, and now we first update our run counter and only later call the job's function; thus it's launch is actually the last thing to be done in the execution chain 
- refactored `TestExecutionSecond` to `TestImmediateExecution`, as this is what was actually being tested here
- refactored `TestAtFuture` to use `t.Run()` and the new `s.start()` method
- fixed `TestRunJobsWithLimit` to tests cases with immediate execution

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
Yes

### Notes

I did my tests manually here, but if possible guys, take a look at some running examples to also check if they are working correctly. 

A simple example of manual testing function that can be called from any testing file: 
```go
func TestManualTesting(t *testing.T) {
	s := NewScheduler(time.UTC)
	s.Every(1).Second().Do(func() {fmt.Println("job 1: ", time.Now().UTC().Format("15:04:05"))})
	s.Every(5).Second().Do(func() {fmt.Println("job 2: ", time.Now().UTC().Format("15:04:05"))})
	s.StartAsync()
	time.Sleep(11 * time.Second)
}```