### PR TITLE
Remove stopChan from Scheduler 

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -55,6 +55,7 @@ func ExampleScheduler_Stop() {
 	s := gocron.NewScheduler(time.UTC)
 	_, _ = s.Every(1).Second().Do(task)
 	s.StartAsync()
+	time.Sleep(time.Second * 5)
 	s.Stop()
 }
 
@@ -120,7 +121,7 @@ func ExampleJob_LastRun() {
 			time.Sleep(time.Second)
 		}
 	}()
-	<-s.StartAsync()
+	s.StartBlocking()
 }
 
 func ExampleJob_NextRun() {
@@ -132,7 +133,7 @@ func ExampleJob_NextRun() {
 			time.Sleep(time.Second)
 		}
 	}()
-	<-s.StartAsync()
+	s.StartAsync()
 }
 
 func ExampleJob_RunCount() {
@@ -144,7 +145,7 @@ func ExampleJob_RunCount() {
 			time.Sleep(time.Second)
 		}
 	}()
-	<-s.StartAsync()
+	s.StartAsync()
 }
 
 func ExampleJob_RemoveAfterLastRun() {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -78,9 +78,9 @@ func TestExecutionSeconds(t *testing.T) {
 		}
 	})
 
-	stop := sched.StartAsync()
+	sched.StartAsync()
 	<-jobDone // Wait job done
-	close(stop)
+	sched.Stop()
 
 	mu.RLock()
 	defer mu.RUnlock()
@@ -389,9 +389,9 @@ func TestScheduler_Stop(t *testing.T) {
 	})
 	t.Run("stops a running scheduler through StartAsync chan", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
-		c := s.StartAsync()
+		s.StartAsync()
 		assert.True(t, s.IsRunning())
-		close(c)
+		s.Stop()
 		time.Sleep(1 * time.Millisecond) // wait for stop goroutine to catch up
 		assert.False(t, s.IsRunning())
 	})

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -387,7 +387,7 @@ func TestScheduler_Stop(t *testing.T) {
 		s.Stop()
 		assert.False(t, s.IsRunning())
 	})
-	t.Run("stops a running scheduler through StartAsync chan", func(t *testing.T) {
+	t.Run("stops a running scheduler calling .Stop()", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		s.StartAsync()
 		assert.True(t, s.IsRunning())


### PR DESCRIPTION
### What does this do?
Remove stopChan from Scheduler to restrict stopping the scheduler only to the Stop function

### Which issue(s) does this PR fix/relate to?
Closes #100 

### List any changes that modify/break current functionality
The `StartAsync()` function will not return the `stopChan` anymore. This is a backward incompatible change

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`