### PR TITLE
Allow starting Jobs in the past (#106)

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -133,6 +133,10 @@ func (s *Scheduler) scheduleNextRun(job *Job) {
 	lastRun := job.LastRun()
 
 	if job.neverRan() {
+		// Increment startAtTime until it is in the future
+		for job.startAtTime.Before(now) && !job.startAtTime.IsZero() {
+			job.startAtTime = job.startAtTime.Add(s.durationToNextRun(job.startAtTime, job))
+		}
 		lastRun = now
 	}
 
@@ -459,7 +463,8 @@ func (s *Scheduler) SetTag(t []string) *Scheduler {
 	return s
 }
 
-// StartAt schedules the next run of the Job
+// StartAt schedules the next run of the Job. If this time is in the past, the configured interval will be used
+// to calculate the next future time
 func (s *Scheduler) StartAt(t time.Time) *Scheduler {
 	job := s.getCurrentJob()
 	job.setStartAtTime(t)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -493,6 +493,18 @@ func TestScheduler_StartAt(t *testing.T) {
 			// test passed
 		}
 	})
+
+	t.Run("start in past", func(t *testing.T) {
+		s := NewScheduler(time.Local)
+		now := time.Now()
+
+		// Start 5 seconds ago and make sure next run is in the future
+		job, _ := s.Every(24).Hours().StartAt(now.Add(-24 * time.Hour).Add(10 * time.Minute)).Do(func() {})
+		assert.False(t, job.getStartsImmediately())
+		s.start()
+		assert.Equal(t, now.Add(10*time.Minute).Truncate(time.Second), job.NextRun().Truncate(time.Second))
+		s.stop()
+	})
 }
 
 func TestScheduler_CalculateNextRun(t *testing.T) {


### PR DESCRIPTION
### What does this do?

This PR adds a loop to increment the Job's `startAtTime` until it is in the future. It will only need to do this if a Job is intentionally set to start in the past, not if it is just defaulted to 0.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves #106 

### List any changes that modify/break current functionality
- If someone is intentionally scheduling something to start at 0 time, it might not work as expected.


### Have you included tests for your changes?
Yes


### Did you document any new/modified functionality?
Yes

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
See #106 for more information
