### PR TITLE
fix bug with limit runs to not stopping jobs

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -384,7 +384,7 @@ func removeAtIndex(jobs []*Job, i int) []*Job {
 	return jobs
 }
 
-// Scheduled checks if specific Job j was already added
+// Scheduled checks if specific job function was already added
 func (s *Scheduler) Scheduled(j interface{}) bool {
 	for _, job := range s.Jobs() {
 		if job.jobFunc == getFunctionName(j) {

--- a/scheduler.go
+++ b/scheduler.go
@@ -55,16 +55,6 @@ func (s *Scheduler) start() {
 
 func (s *Scheduler) runJobs(jobs []*Job) {
 	for _, j := range jobs {
-		if j.getStartsImmediately() {
-			s.run(j)
-			j.setStartsImmediately(false)
-		}
-		if !j.shouldRun() {
-			if j.getRemoveAfterLastRun() {
-				s.RemoveByReference(j)
-			}
-			continue
-		}
 		s.scheduleNextRun(j)
 	}
 }
@@ -132,8 +122,20 @@ func (s *Scheduler) scheduleNextRun(job *Job) {
 	now := s.now()
 	lastRun := job.LastRun()
 
+	if job.getStartsImmediately() {
+		s.run(job)
+		job.setStartsImmediately(false)
+	}
+
 	if job.neverRan() {
 		lastRun = now
+	}
+
+	if !job.shouldRun() {
+		if job.getRemoveAfterLastRun() {
+			s.RemoveByReference(job)
+		}
+		return
 	}
 
 	durationToNextRun := s.durationToNextRun(lastRun, job)


### PR DESCRIPTION
### What does this do?

- fixes the bug where a limit of runs was not stopping the job
- this was happening because `scheduleNextRun` became a recursive function, and so the checks for `shouldRun` were never called. the check happens in the `runJobs` func which is only called the first time it's started.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
closes #111 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
👍 

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
