### PR TITLE
Every() accepts int, time.Duration, string to allow any custom duration between runs

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -46,6 +46,12 @@ func ExampleScheduler_StartAsync() {
 	s.StartAsync()
 }
 
+func ExampleScheduler_EveryDuration() {
+	s := gocron.NewScheduler(time.UTC)
+	_, _ = s.EveryDuration(500 * time.Millisecond).Do(task)
+	s.StartAsync()
+}
+
 func ExampleScheduler_StartAt() {
 	s := gocron.NewScheduler(time.UTC)
 	specificTime := time.Date(2019, time.November, 10, 15, 0, 0, 0, time.UTC)

--- a/example_test.go
+++ b/example_test.go
@@ -46,9 +46,11 @@ func ExampleScheduler_StartAsync() {
 	s.StartAsync()
 }
 
-func ExampleScheduler_EveryDuration() {
+func ExampleScheduler_Every() {
 	s := gocron.NewScheduler(time.UTC)
-	_, _ = s.EveryDuration(500 * time.Millisecond).Do(task)
+	_, _ = s.Every(1).Second().Do(task)
+	_, _ = s.Every(1 * time.Second).Do(task)
+	_, _ = s.Every("1s").Do(task)
 	s.StartAsync()
 }
 

--- a/gocron.go
+++ b/gocron.go
@@ -45,6 +45,7 @@ const (
 	days
 	weeks
 	months
+	duration
 )
 
 func callJobFuncWithParams(jobFunc interface{}, params []interface{}) ([]reflect.Value, error) {

--- a/gocron.go
+++ b/gocron.go
@@ -27,6 +27,8 @@ var (
 	ErrJobNotFoundWithTag    = errors.New("no jobs found with given tag")
 	ErrUnsupportedTimeFormat = errors.New("the given time format is not supported")
 	ErrInvalidInterval       = errors.New(".Every() interval must be greater than 0")
+	ErrInvalidIntervalType   = errors.New(".Every() interval must be int, time.Duration, or string")
+	ErrInvalidSelection      = errors.New("an .Every() duration interval cannot be used with units (e.g. .Seconds())")
 )
 
 // regex patterns for supported time formats

--- a/job.go
+++ b/job.go
@@ -6,12 +6,10 @@ import (
 	"time"
 )
 
-type jobInterval uint64
-
 // Job struct stores the information necessary to run a Job
 type Job struct {
 	sync.RWMutex
-	interval          jobInterval              // pause interval * unit between runs
+	interval          int                      // pause interval * unit between runs
 	duration          time.Duration            // time duration between runs
 	unit              timeUnit                 // time units, ,e.g. 'minutes', 'hours'...
 	startsImmediately bool                     // if the Job should run upon scheduler start
@@ -38,9 +36,9 @@ type runConfig struct {
 }
 
 // NewJob creates a new Job with the provided interval
-func NewJob(interval uint64) *Job {
+func NewJob(interval int) *Job {
 	return &Job{
-		interval:          jobInterval(interval),
+		interval:          interval,
 		lastRun:           time.Time{},
 		nextRun:           time.Time{},
 		funcs:             make(map[string]interface{}),

--- a/job.go
+++ b/job.go
@@ -12,6 +12,7 @@ type jobInterval uint64
 type Job struct {
 	sync.RWMutex
 	interval          jobInterval              // pause interval * unit between runs
+	duration          time.Duration            // time duration between runs
 	unit              timeUnit                 // time units, ,e.g. 'minutes', 'hours'...
 	startsImmediately bool                     // if the Job should run upon scheduler start
 	jobFunc           string                   // the Job jobFunc to run, func[jobFunc]

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -64,6 +64,28 @@ func TestInvalidEveryInterval(t *testing.T) {
 	assert.EqualError(t, err, ErrInvalidInterval.Error())
 }
 
+func TestScheduler_EveryDuration(t *testing.T) {
+	s := NewScheduler(time.UTC)
+	semaphore := make(chan bool)
+
+	_, err := s.EveryDuration(100 * time.Millisecond).Do(func() {
+		semaphore <- true
+	})
+	require.NoError(t, err)
+
+	s.StartAsync()
+
+	var counter int
+
+	select {
+	case <-time.After(500 * time.Millisecond):
+		s.Stop()
+	case <-semaphore:
+		counter++
+	}
+	assert.Equal(t, 6, counter)
+}
+
 func TestExecutionSeconds(t *testing.T) {
 	s := NewScheduler(time.UTC)
 	jobDone := make(chan bool)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -79,8 +79,7 @@ func TestScheduler_EveryDuration(t *testing.T) {
 
 	now := time.Now()
 	for time.Now().Before(now.Add(500 * time.Millisecond)) {
-		select {
-		case <-semaphore:
+		if <-semaphore {
 			counter++
 		}
 	}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -77,12 +77,14 @@ func TestScheduler_EveryDuration(t *testing.T) {
 
 	var counter int
 
-	select {
-	case <-time.After(500 * time.Millisecond):
-		s.Stop()
-	case <-semaphore:
-		counter++
+	now := time.Now()
+	for time.Now().Before(now.Add(500 * time.Millisecond)) {
+		select {
+		case <-semaphore:
+			counter++
+		}
 	}
+	s.Stop()
 	assert.Equal(t, 6, counter)
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2,6 +2,7 @@ package gocron
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -62,7 +63,7 @@ func TestInvalidEveryInterval(t *testing.T) {
 	}{
 		{"zero", 0, ErrInvalidInterval.Error()},
 		{"negative", -1, ErrInvalidInterval.Error()},
-		{"invalid string duration", "bad", "time: invalid duration \"bad\""},
+		{"invalid string duration", "bad", "time: invalid duration"},
 	}
 
 	s := NewScheduler(time.UTC)
@@ -70,8 +71,10 @@ func TestInvalidEveryInterval(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			_, err := s.Every(tc.interval).Do(func() {})
-
-			assert.EqualError(t, err, tc.expectedError)
+			require.Error(t, err)
+			// wonky way to assert on the error message, but between go 1.14
+			// and go 1.15 the error value was wrapped in quotes
+			assert.True(t, strings.HasPrefix(err.Error(), tc.expectedError))
 		})
 	}
 

--- a/timeHelper.go
+++ b/timeHelper.go
@@ -2,11 +2,12 @@ package gocron
 
 import "time"
 
+var _ timeWrapper = (*trueTime)(nil)
+
 type timeWrapper interface {
 	Now(*time.Location) time.Time
 	Unix(int64, int64) time.Time
 	Sleep(time.Duration)
-	NewTicker(time.Duration) *time.Ticker
 }
 
 type trueTime struct{}
@@ -21,8 +22,4 @@ func (t *trueTime) Unix(sec int64, nsec int64) time.Time {
 
 func (t *trueTime) Sleep(d time.Duration) {
 	time.Sleep(d)
-}
-
-func (t *trueTime) NewTicker(d time.Duration) *time.Ticker {
-	return time.NewTicker(d)
 }


### PR DESCRIPTION
### What does this do?
Changes the `Every()` func in the scheduler allowing users to schedule any time.Duration between job runs via:
- int + unit (e.g. Seconds)
- time.Duration
- string representation of time.Duration e.g. `1s`

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
closes #44 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
👍 

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
