### PR TITLE
implement executor to reduce go routines / mutexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ See also these two great articles:
 
 If you want to chat, you can find us at Slack! [<img src="https://img.shields.io/badge/gophers-gocron-brightgreen?logo=slack">](https://gophers.slack.com/archives/CQ7T0T1FW)
 
+## Examples
+
+Take a look in our [go docs](https://pkg.go.dev/github.com/go-co-op/gocron#pkg-examples)
+
 ## FAQ
 
 * Q: I'm running multiple pods on a distributed environment. How can I make a job not run once per pod causing duplication? 

--- a/executor.go
+++ b/executor.go
@@ -1,0 +1,34 @@
+package gocron
+
+import (
+	"sync"
+)
+
+type executor struct {
+	jobFunctions chan jobFunction
+	stop         chan struct{}
+}
+
+func newExecutor() executor {
+	return executor{
+		jobFunctions: make(chan jobFunction, 1),
+		stop:         make(chan struct{}, 1),
+	}
+}
+
+func (e *executor) start() {
+	wg := sync.WaitGroup{}
+	for {
+		select {
+		case f := <-e.jobFunctions:
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				callJobFuncWithParams(f.functions[f.name], f.params[f.name])
+			}()
+		case <-e.stop:
+			wg.Wait()
+			return
+		}
+	}
+}

--- a/gocron.go
+++ b/gocron.go
@@ -17,7 +17,6 @@ import (
 // Error declarations for gocron related errors
 var (
 	ErrTimeFormat            = errors.New("time format error")
-	ErrParamsNotAdapted      = errors.New("the number of params is not adapted")
 	ErrNotAFunction          = errors.New("only functions can be schedule into the job queue")
 	ErrNotScheduledWeekday   = errors.New("job not scheduled weekly on a weekday")
 	ErrJobNotFoundWithTag    = errors.New("no jobs found with given tag")
@@ -46,16 +45,16 @@ const (
 	duration
 )
 
-func callJobFuncWithParams(jobFunc interface{}, params []interface{}) ([]reflect.Value, error) {
+func callJobFuncWithParams(jobFunc interface{}, params []interface{}) {
 	f := reflect.ValueOf(jobFunc)
 	if len(params) != f.Type().NumIn() {
-		return nil, ErrParamsNotAdapted
+		return
 	}
 	in := make([]reflect.Value, len(params))
 	for k, param := range params {
 		in[k] = reflect.ValueOf(param)
 	}
-	return f.Call(in), nil
+	f.Call(in)
 }
 
 func getFunctionName(fn interface{}) string {

--- a/job_test.go
+++ b/job_test.go
@@ -102,9 +102,9 @@ func TestJob_LimitRunsTo(t *testing.T) {
 	j, _ := NewScheduler(time.Local).Every(1).Second().Do(func() {})
 	j.LimitRunsTo(2)
 	assert.Equal(t, j.shouldRun(), true, "Expecting it to run again")
-	j.run()
+	j.runCount++
 	assert.Equal(t, j.shouldRun(), true, "Expecting it to run again")
-	j.run()
+	j.runCount++
 	assert.Equal(t, j.shouldRun(), false, "Not expecting it to run again")
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -354,7 +354,7 @@ func TestScheduler_Remove(t *testing.T) {
 
 		s.StartAsync()
 
-		s.Remove(j.funcs[j.jobFunc])
+		s.Remove(j.functions[j.name])
 
 		select {
 		case <-time.After(2 * time.Second):


### PR DESCRIPTION
### What does this do?

Spins up an executor that runs job functions passed to it on a chan. This changes it so that only the function of the job is passed to a separate goroutine and reduces the references to the job object by different goroutines.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #101 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
implicitly tested by all tests

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [x] Updated `README.md`
  - added a link to our examples on the go docs

### Notes
