### PR TITLE
fix race condition

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -445,6 +445,8 @@ func (s *Scheduler) RemoveAfterLastRun() *Scheduler {
 
 // TaskPresent checks if specific job's function was added to the scheduler.
 func (s *Scheduler) TaskPresent(j interface{}) bool {
+	s.jobsMutex.RLock()
+	defer s.jobsMutex.RUnlock()
 	for _, job := range s.Jobs() {
 		if job.name == getFunctionName(j) {
 			return true
@@ -454,6 +456,8 @@ func (s *Scheduler) TaskPresent(j interface{}) bool {
 }
 
 func (s *Scheduler) jobPresent(j *Job) bool {
+	s.jobsMutex.RLock()
+	defer s.jobsMutex.RUnlock()
 	for _, job := range s.Jobs() {
 		if job == j {
 			return true


### PR DESCRIPTION
### What does this do?

jobs() method lock the jobs to get list of them but after we call Jobs(),this method lock jobs until get list of them, but after this method finished, the caller of this method should need lock the jobs because maybe it need to check current state and no past state, and if in this state removebytag() remove any job this may generate race condition (because used append() function on job in removebytag())
### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
