### PR TITLE
clear should stop all jobs before removing

### DIFF
--- a/job.go
+++ b/job.go
@@ -230,6 +230,8 @@ func (j *Job) RunCount() int {
 }
 
 func (j *Job) stopTimer() {
+	j.Lock()
+	defer j.Unlock()
 	if j.timer != nil {
 		j.timer.Stop()
 	}

--- a/scheduler.go
+++ b/scheduler.go
@@ -490,6 +490,9 @@ func (s *Scheduler) jobPresent(j *Job) bool {
 
 // Clear clear all Jobs from this scheduler
 func (s *Scheduler) Clear() {
+	for _, j := range s.Jobs() {
+		j.stopTimer()
+	}
 	s.setJobs(make([]*Job, 0))
 }
 


### PR DESCRIPTION
### What does this do?

Stops all jobs in the scheduler before removing when clear is called

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->

resolves https://github.com/go-co-op/gocron/issues/133

### List any changes that modify/break current functionality


### Have you included tests for your changes?
👍 

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
