### PR TITLE
allow enforcing uniqueness across tags

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -525,6 +525,18 @@ func ExampleScheduler_Tag() {
 	// [tag]
 }
 
+func ExampleScheduler_TagsUnique() {
+	s := gocron.NewScheduler(time.UTC)
+	s.TagsUnique()
+
+	_, _ = s.Every(1).Week().Tag("foo").Do(task)
+	_, err := s.Every(1).Week().Tag("foo").Do(task)
+
+	fmt.Println(err)
+	// Output:
+	// a non-unique tag was set on the job: foo
+}
+
 func ExampleScheduler_TaskPresent() {
 	s := gocron.NewScheduler(time.UTC)
 

--- a/gocron.go
+++ b/gocron.go
@@ -24,9 +24,9 @@ var (
 	ErrInvalidInterval               = errors.New(".Every() interval must be greater than 0")
 	ErrInvalidIntervalType           = errors.New(".Every() interval must be int, time.Duration, or string")
 	ErrInvalidIntervalUnitsSelection = errors.New("an .Every() duration interval cannot be used with units (e.g. .Seconds())")
-
-	ErrAtTimeNotSupported  = errors.New("the At() not supported for time unit")
-	ErrWeekdayNotSupported = errors.New("weekday is not supported for time unit")
+	ErrAtTimeNotSupported            = errors.New("the At() not supported for time unit")
+	ErrWeekdayNotSupported           = errors.New("weekday is not supported for time unit")
+	ErrTagsUnique                    = func(tag string) error { return fmt.Errorf("a non-unique tag was set on the job: %s", tag) }
 )
 
 func wrapOrError(toWrap error, err error) error {

--- a/scheduler.go
+++ b/scheduler.go
@@ -26,6 +26,8 @@ type Scheduler struct {
 
 	time     timeWrapper // wrapper around time.Time
 	executor *executor   // executes jobs passed via chan
+
+	tags map[string]struct{} // for storing tags when unique tags is set
 }
 
 // NewScheduler creates a new Scheduler
@@ -564,6 +566,17 @@ func (s *Scheduler) At(t string) *Scheduler {
 // Tag will add a tag when creating a job.
 func (s *Scheduler) Tag(t ...string) *Scheduler {
 	job := s.getCurrentJob()
+
+	if s.tags != nil {
+		for _, tag := range t {
+			if _, ok := s.tags[tag]; ok {
+				job.err = wrapOrError(job.err, ErrTagsUnique(tag))
+				return s
+			}
+			s.tags[tag] = struct{}{}
+		}
+	}
+
 	job.tags = t
 	return s
 }
@@ -712,4 +725,12 @@ func (s *Scheduler) getCurrentJob() *Job {
 
 func (s *Scheduler) now() time.Time {
 	return s.time.Now(s.Location())
+}
+
+// TagsUnique forces job tags to be unique across the scheduler
+// when adding tags with (s *Scheduler) Tag().
+// This does not enforce uniqueness on tags added via
+// (j *Job) Tag()
+func (s *Scheduler) TagsUnique() {
+	s.tags = make(map[string]struct{})
 }


### PR DESCRIPTION
### What does this do?
- allows enforcing tags to be unique across the scheduler
- there isn't a good way I can see to support forcing jobs tagged via the job.Tag() method to be unique as they have no knowledge of the scheduler. I considered a global tags map, but that would then be unique across all schedulers that the user may define. Limiting the scope to a single scheduler seems better, albeit with the limitation that the scheduler.Tag() method must be used. 

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
#131 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
👍 

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
