### PR TITLE
a bunch of things

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -12,8 +12,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.14
-          - 1.15
           - 1.16
     name: lint and test
     runs-on: ubuntu-latest

--- a/example_test.go
+++ b/example_test.go
@@ -13,7 +13,7 @@ var task = func() {}
 // ----------------------JOB-FUNCTIONS----------------------------------
 // ---------------------------------------------------------------------
 
-func ExampleJob_Err() {
+func ExampleJob_Error() {
 	s := gocron.NewScheduler(time.UTC)
 	s.Every(1).Day().At("bad time")
 	j := s.Jobs()[0]

--- a/example_test.go
+++ b/example_test.go
@@ -17,7 +17,7 @@ func ExampleJob_Err() {
 	s := gocron.NewScheduler(time.UTC)
 	s.Every(1).Day().At("bad time")
 	j := s.Jobs()[0]
-	fmt.Println(j.Err())
+	fmt.Println(j.Error())
 	// Output:
 	// the given time format is not supported
 }
@@ -46,14 +46,6 @@ func ExampleJob_NextRun() {
 			time.Sleep(time.Second)
 		}
 	}()
-	s.StartAsync()
-}
-
-func ExampleJob_RemoveAfterLastRun() {
-	s := gocron.NewScheduler(time.UTC)
-	job, _ := s.Every(1).Second().Do(task)
-	job.LimitRunsTo(1)
-	job.RemoveAfterLastRun()
 	s.StartAsync()
 }
 
@@ -358,19 +350,6 @@ func ExampleScheduler_Remove() {
 	s.Remove(task)
 	fmt.Println(s.Len())
 	// Output:
-	// 0
-}
-
-func ExampleScheduler_RemoveAfterLastRun() {
-	s := gocron.NewScheduler(time.UTC)
-
-	j, _ := s.Every(1).Second().LimitRunsTo(1).RemoveAfterLastRun().Do(task)
-	s.StartAsync()
-	s.Stop()
-	fmt.Println(j.RunCount())
-	fmt.Println(s.Len())
-	// Output:
-	// 1
 	// 0
 }
 

--- a/gocron.go
+++ b/gocron.go
@@ -25,7 +25,7 @@ var (
 	ErrInvalidIntervalType           = errors.New(".Every() interval must be int, time.Duration, or string")
 	ErrInvalidIntervalUnitsSelection = errors.New("an .Every() duration interval cannot be used with units (e.g. .Seconds())")
 
-	ErrAtTimeNotSupported  = errors.New("the At() not supported for time unit")
+	ErrAtTimeNotSupported  = errors.New("the At() method is not supported for this time unit")
 	ErrWeekdayNotSupported = errors.New("weekday is not supported for time unit")
 )
 
@@ -49,7 +49,8 @@ type timeUnit int
 
 const (
 	// default unit is seconds
-	seconds timeUnit = iota
+	milliseconds timeUnit = iota
+	seconds
 	minutes
 	hours
 	days

--- a/gocron.go
+++ b/gocron.go
@@ -26,9 +26,8 @@ var (
 	ErrInvalidIntervalUnitsSelection = errors.New("an .Every() duration interval cannot be used with units (e.g. .Seconds())")
 
 	ErrAtTimeNotSupported  = errors.New("the At() method is not supported for this time unit")
-	ErrWeekdayNotSupported           = errors.New("weekday is not supported for time unit")
-	ErrTagsUnique                    = func(tag string) error { return fmt.Errorf("a non-unique tag was set on the job: %s", tag) }
-
+	ErrWeekdayNotSupported = errors.New("weekday is not supported for time unit")
+	ErrTagsUnique          = func(tag string) error { return fmt.Errorf("a non-unique tag was set on the job: %s", tag) }
 )
 
 func wrapOrError(toWrap error, err error) error {

--- a/scheduler.go
+++ b/scheduler.go
@@ -158,9 +158,7 @@ func (s *Scheduler) scheduleNextRun(job *Job) {
 	}
 
 	if !job.shouldRun() {
-		if job.getRemoveAfterLastRun() {
-			s.RemoveByReference(job)
-		}
+		s.RemoveByReference(job)
 		return
 	}
 
@@ -180,7 +178,7 @@ func (s *Scheduler) durationToNextRun(lastRun time.Time, job *Job) time.Duration
 
 	var d time.Duration
 	switch job.unit {
-	case seconds, minutes, hours:
+	case milliseconds, seconds, minutes, hours:
 		d = s.calculateDuration(job)
 	case days:
 		d = s.calculateDays(job, lastRun)
@@ -280,6 +278,8 @@ func (s *Scheduler) calculateDuration(job *Job) time.Duration {
 
 	interval := job.interval
 	switch job.unit {
+	case milliseconds:
+		return time.Duration(interval) * time.Millisecond
 	case seconds:
 		return time.Duration(interval) * time.Second
 	case minutes:
@@ -326,7 +326,7 @@ func (s *Scheduler) Every(interval interface{}) *Scheduler {
 	case int:
 		job := NewJob(interval)
 		if interval <= 0 {
-			job.err = wrapOrError(job.err, ErrInvalidInterval)
+			job.error = wrapOrError(job.error, ErrInvalidInterval)
 		}
 		s.setJobs(append(s.Jobs(), job))
 	case time.Duration:
@@ -338,14 +338,14 @@ func (s *Scheduler) Every(interval interface{}) *Scheduler {
 		job := NewJob(0)
 		d, err := time.ParseDuration(interval)
 		if err != nil {
-			job.err = wrapOrError(job.err, err)
+			job.error = wrapOrError(job.error, err)
 		}
 		job.duration = d
 		job.unit = duration
 		s.setJobs(append(s.Jobs(), job))
 	default:
 		job := NewJob(0)
-		job.err = wrapOrError(job.err, ErrInvalidIntervalType)
+		job.error = wrapOrError(job.error, ErrInvalidIntervalType)
 		s.setJobs(append(s.Jobs(), job))
 	}
 	return s
@@ -442,8 +442,8 @@ func removeAtIndex(jobs []*Job, i int) []*Job {
 	return jobs
 }
 
-// LimitRunsTo limits the number of executions of this job to n. However,
-// the job will still remain in the scheduler
+// LimitRunsTo limits the number of executions of this job to n.
+// Upon reaching the limit, the job is removed from the scheduler.
 func (s *Scheduler) LimitRunsTo(i int) *Scheduler {
 	job := s.getCurrentJob()
 	job.LimitRunsTo(i)
@@ -455,13 +455,6 @@ func (s *Scheduler) LimitRunsTo(i int) *Scheduler {
 func (s *Scheduler) SingletonMode() *Scheduler {
 	job := s.getCurrentJob()
 	job.SingletonMode()
-	return s
-}
-
-// RemoveAfterLastRun sets the job to be removed after it's last run (when limited)
-func (s *Scheduler) RemoveAfterLastRun() *Scheduler {
-	job := s.getCurrentJob()
-	job.RemoveAfterLastRun()
 	return s
 }
 
@@ -513,18 +506,18 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 	job := s.getCurrentJob()
 
 	if job.atTime != 0 && job.unit <= hours {
-		job.err = wrapOrError(job.err, ErrAtTimeNotSupported)
+		job.error = wrapOrError(job.error, ErrAtTimeNotSupported)
 	}
 
 	if job.scheduledWeekday != nil && job.unit != weeks {
-		job.err = wrapOrError(job.err, ErrWeekdayNotSupported)
+		job.error = wrapOrError(job.error, ErrWeekdayNotSupported)
 	}
 
-	if job.err != nil {
+	if job.error != nil {
 		// delete the job from the scheduler as this job
 		// cannot be executed
 		s.RemoveByReference(job)
-		return nil, job.err
+		return nil, job.error
 	}
 
 	typ := reflect.TypeOf(jobFun)
@@ -548,15 +541,24 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 }
 
 // At schedules the Job at a specific time of day in the form "HH:MM:SS" or "HH:MM"
-func (s *Scheduler) At(t string) *Scheduler {
+// or time.Time (note that only the hours, minutes, seconds and nanos are used).
+func (s *Scheduler) At(i interface{}) *Scheduler {
 	job := s.getCurrentJob()
-	hour, min, sec, err := parseTime(t)
-	if err != nil {
-		job.err = wrapOrError(job.err, err)
-		return s
+
+	switch t := i.(type) {
+	case string:
+		hour, min, sec, err := parseTime(t)
+		if err != nil {
+			job.error = wrapOrError(job.error, err)
+			return s
+		}
+		// save atTime start as duration from midnight
+		job.setAtTime(time.Duration(hour)*time.Hour + time.Duration(min)*time.Minute + time.Duration(sec)*time.Second)
+	case time.Time:
+		job.setAtTime(time.Duration(t.Hour())*time.Hour + time.Duration(t.Minute())*time.Minute + time.Duration(t.Second())*time.Second + time.Duration(t.Nanosecond())*time.Nanosecond)
+	default:
+		job.error = wrapOrError(job.error, ErrUnsupportedTimeFormat)
 	}
-	// save atTime start as duration from midnight
-	job.setAtTime(time.Duration(hour)*time.Hour + time.Duration(min)*time.Minute + time.Duration(sec)*time.Second)
 	job.startsImmediately = false
 	return s
 }
@@ -581,9 +583,20 @@ func (s *Scheduler) StartAt(t time.Time) *Scheduler {
 func (s *Scheduler) setUnit(unit timeUnit) {
 	job := s.getCurrentJob()
 	if job.unit == duration {
-		job.err = wrapOrError(job.err, ErrInvalidIntervalUnitsSelection)
+		job.error = wrapOrError(job.error, ErrInvalidIntervalUnitsSelection)
 	}
 	job.unit = unit
+}
+
+// Second sets the unit with seconds
+func (s *Scheduler) Millisecond() *Scheduler {
+	return s.Milliseconds()
+}
+
+// Seconds sets the unit with seconds
+func (s *Scheduler) Milliseconds() *Scheduler {
+	s.setUnit(milliseconds)
+	return s
 }
 
 // Second sets the unit with seconds

--- a/scheduler.go
+++ b/scheduler.go
@@ -572,7 +572,7 @@ func (s *Scheduler) Tag(t ...string) *Scheduler {
 	if s.tags != nil {
 		for _, tag := range t {
 			if _, ok := s.tags[tag]; ok {
-				job.err = wrapOrError(job.err, ErrTagsUnique(tag))
+				job.error = wrapOrError(job.error, ErrTagsUnique(tag))
 				return s
 			}
 			s.tags[tag] = struct{}{}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -783,35 +783,6 @@ func TestRunJobsWithLimit(t *testing.T) {
 		assert.Equal(t, 1, counter)
 	})
 
-	// this test isn't designed well and the functionality isn't working
-	//t.Run("change limit", func(t *testing.T) {
-	//	semaphore := make(chan bool)
-	//
-	//	s := NewScheduler(time.UTC)
-	//
-	//	j, err := s.Every(1).Second().Do(func() {
-	//		semaphore <- true
-	//	})
-	//	require.NoError(t, err)
-	//	j.LimitRunsTo(1)
-	//
-	//	s.StartAsync()
-	//	time.Sleep(1 * time.Second)
-	//
-	//	j.LimitRunsTo(2)
-	//	time.Sleep(1 * time.Second)
-	//
-	//	var counter int
-	//	select {
-	//	case <-time.After(2 * time.Second):
-	//		assert.Equal(t, 2, counter)
-	//		// test passed
-	//	case <-semaphore:
-	//		counter++
-	//		require.LessOrEqual(t, counter, 2)
-	//	}
-	//})
-
 	t.Run("remove after last run", func(t *testing.T) {
 		semaphore := make(chan bool)
 
@@ -822,7 +793,6 @@ func TestRunJobsWithLimit(t *testing.T) {
 		})
 		require.NoError(t, err)
 		j.LimitRunsTo(1)
-		j.RemoveAfterLastRun()
 
 		s.StartAsync()
 		time.Sleep(2 * time.Second)
@@ -1060,30 +1030,4 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 			assert.Equal(t, tc.expectedRuns, counter)
 		})
 	}
-}
-
-func TestScheduler_RemoveAfterLastRun(t *testing.T) {
-	t.Run("job removed after the last run", func(t *testing.T) {
-		semaphore := make(chan bool)
-
-		s := NewScheduler(time.UTC)
-
-		_, err := s.Every(1).Second().LimitRunsTo(1).RemoveAfterLastRun().Do(func() {
-			semaphore <- true
-		})
-		require.NoError(t, err)
-
-		s.StartAsync()
-		time.Sleep(2 * time.Second)
-
-		var counter int
-		select {
-		case <-time.After(2 * time.Second):
-			assert.Equal(t, 1, counter)
-			assert.Zero(t, s.Len())
-		case <-semaphore:
-			counter++
-			require.LessOrEqual(t, counter, 1)
-		}
-	})
 }


### PR DESCRIPTION
### What does this do?
- renamed job.Err to job. Error
- remove, removeAfterLastRun - just remove when a job hits the limit by default. we don't have any way to restart a job, so there is not point in keeping them in the scheduler once they're stopped
- add milliseconds explicitly as a unit (already available using the Every(time.Duration) option)
- allow At() to accept an interface, string or time.Time (parsing hours down if time.Time)

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
