### PR TITLE
#142 validation of params is added

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -28,6 +28,7 @@ var (
 	ErrAtTimeNotSupported  = errors.New("the At() method is not supported for this time unit")
 	ErrWeekdayNotSupported = errors.New("weekday is not supported for time unit")
 	ErrTagsUnique          = func(tag string) error { return fmt.Errorf("a non-unique tag was set on the job: %s", tag) }
+	ErrWrongParams         = errors.New("wrong list of params")
 )
 
 func wrapOrError(toWrap error, err error) error {

--- a/scheduler.go
+++ b/scheduler.go
@@ -532,7 +532,8 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 	f := reflect.ValueOf(jobFun)
 	if len(params) != f.Type().NumIn() {
 		s.RemoveByReference(job)
-		return nil, ErrWrongParams
+		job.error = wrapOrError(job.error, ErrWrongParams)
+		return nil, job.error
 	}
 
 	fname := getFunctionName(jobFun)

--- a/scheduler.go
+++ b/scheduler.go
@@ -529,6 +529,12 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 		return nil, ErrNotAFunction
 	}
 
+	f := reflect.ValueOf(jobFun)
+	if len(params) != f.Type().NumIn() {
+		s.RemoveByReference(job)
+		return nil, ErrWrongParams
+	}
+
 	fname := getFunctionName(jobFun)
 	job.functions[fname] = jobFun
 	job.params[fname] = params

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1058,3 +1058,31 @@ func TestScheduler_TagsUnique(t *testing.T) {
 	assert.EqualError(t, err, ErrTagsUnique(bar).Error())
 
 }
+
+func TestScheduler_LessParamsThanExpected(t *testing.T) {
+
+	s := NewScheduler(time.UTC)
+
+	f := func(s1, s2 string) {
+		fmt.Println("ok")
+	}
+
+	p := []interface{}{"p1"}
+	_, err := s.Every(1).Days().StartAt(time.Now().UTC().Add(time.Second*10)).Do(f, p...)
+	assert.EqualError(t, err, ErrWrongParams.Error())
+
+}
+
+func TestScheduler_MoreParamsThanExpected(t *testing.T) {
+
+	s := NewScheduler(time.UTC)
+
+	f := func(s1, s2 string) {
+		fmt.Println("ok")
+	}
+
+	p := []interface{}{"p1", "p2", "p3"}
+	_, err := s.Every(1).Days().StartAt(time.Now().UTC().Add(time.Second*10)).Do(f, p...)
+	assert.EqualError(t, err, ErrWrongParams.Error())
+
+}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1059,30 +1059,24 @@ func TestScheduler_TagsUnique(t *testing.T) {
 
 }
 
-func TestScheduler_LessParamsThanExpected(t *testing.T) {
-
-	s := NewScheduler(time.UTC)
-
-	f := func(s1, s2 string) {
-		fmt.Println("ok")
+func TestScheduler_DoParameterValidation(t *testing.T) {
+	testCases := []struct {
+		description string
+		parameters  []interface{}
+	}{
+		{"less than expected", []interface{}{"p1"}},
+		{"more than expected", []interface{}{"p1", "p2", "p3"}},
 	}
 
-	p := []interface{}{"p1"}
-	_, err := s.Every(1).Days().StartAt(time.Now().UTC().Add(time.Second*10)).Do(f, p...)
-	assert.EqualError(t, err, ErrWrongParams.Error())
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			s := NewScheduler(time.UTC)
+			f := func(s1, s2 string) {
+				fmt.Println("ok")
+			}
 
-}
-
-func TestScheduler_MoreParamsThanExpected(t *testing.T) {
-
-	s := NewScheduler(time.UTC)
-
-	f := func(s1, s2 string) {
-		fmt.Println("ok")
+			_, err := s.Every(1).Days().StartAt(time.Now().UTC().Add(time.Second*10)).Do(f, tc.parameters...)
+			assert.EqualError(t, err, ErrWrongParams.Error())
+		})
 	}
-
-	p := []interface{}{"p1", "p2", "p3"}
-	_, err := s.Every(1).Days().StartAt(time.Now().UTC().Add(time.Second*10)).Do(f, p...)
-	assert.EqualError(t, err, ErrWrongParams.Error())
-
 }


### PR DESCRIPTION
### What does this do?

It introduces additional validation of params in Scheduler.Do. If list of passed params doesn't correspond to original function params it returns an error.

### Which issue(s) does this PR fix/relate to?
#142 


### List any changes that modify/break current functionality


### Have you included tests for your changes?

TestScheduler_LessParamsThanExpected
TestScheduler_MoreParamsThanExpected

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
