### PR TITLE
Support rescheduling jobs

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -553,7 +553,7 @@ func ExampleScheduler_Update() {
 	j, _ = s.Job(j).Every("10m").Update()
 
 	time.Sleep(30 * time.Minute)
-	j, _ = s.Job(j).Every(1).Day().At("02:00").Update()
+	_, _ = s.Job(j).Every(1).Day().At("02:00").Update()
 }
 
 func ExampleScheduler_Wednesday() {

--- a/example_test.go
+++ b/example_test.go
@@ -545,6 +545,17 @@ func ExampleScheduler_Tuesday() {
 	// Tuesday
 }
 
+func ExampleScheduler_Update() {
+	s := gocron.NewScheduler(time.UTC)
+	j, _ := s.Every("1s").Do(func() {})
+
+	time.Sleep(10 * time.Second)
+	j, _ = s.Job(j).Every("10m").Update()
+
+	time.Sleep(30 * time.Minute)
+	j, _ = s.Job(j).Every(1).Day().At("02:00").Update()
+}
+
 func ExampleScheduler_Wednesday() {
 	s := gocron.NewScheduler(time.UTC)
 	j, _ := s.Every(1).Day().Wednesday().Do(task)

--- a/example_test.go
+++ b/example_test.go
@@ -241,6 +241,18 @@ func ExampleScheduler_IsRunning() {
 	// true
 }
 
+func ExampleScheduler_Job() {
+	s := gocron.NewScheduler(time.UTC)
+	j, _ := s.Every("1s").Do(func() {})
+	s.StartAsync()
+
+	time.Sleep(10 * time.Second)
+	_, _ = s.Job(j).Every("10m").Update()
+
+	time.Sleep(30 * time.Minute)
+	_, _ = s.Job(j).Every(1).Day().At("02:00").Update()
+}
+
 func ExampleScheduler_Jobs() {
 	s := gocron.NewScheduler(time.UTC)
 
@@ -290,6 +302,24 @@ func ExampleScheduler_Location() {
 	fmt.Println(s.Location())
 	// Output:
 	// UTC
+}
+
+func ExampleScheduler_Millisecond() {
+	s := gocron.NewScheduler(time.UTC)
+
+	_, _ = s.Every(1).Millisecond().Do(task)
+	_, _ = s.Every(1).Milliseconds().Do(task)
+	_, _ = s.Every("1ms").Seconds().Do(task)
+	_, _ = s.Every(time.Millisecond).Seconds().Do(task)
+}
+
+func ExampleScheduler_Milliseconds() {
+	s := gocron.NewScheduler(time.UTC)
+
+	_, _ = s.Every(1).Millisecond().Do(task)
+	_, _ = s.Every(1).Milliseconds().Do(task)
+	_, _ = s.Every("1ms").Seconds().Do(task)
+	_, _ = s.Every(time.Millisecond).Seconds().Do(task)
 }
 
 func ExampleScheduler_Minute() {
@@ -548,9 +578,10 @@ func ExampleScheduler_Tuesday() {
 func ExampleScheduler_Update() {
 	s := gocron.NewScheduler(time.UTC)
 	j, _ := s.Every("1s").Do(func() {})
+	s.StartAsync()
 
 	time.Sleep(10 * time.Second)
-	j, _ = s.Job(j).Every("10m").Update()
+	_, _ = s.Job(j).Every("10m").Update()
 
 	time.Sleep(30 * time.Minute)
 	_, _ = s.Job(j).Every(1).Day().At("02:00").Update()

--- a/executor.go
+++ b/executor.go
@@ -2,6 +2,7 @@ package gocron
 
 import (
 	"context"
+	"log"
 	"sync"
 
 	"golang.org/x/sync/semaphore"
@@ -45,6 +46,7 @@ func (e *executor) start() {
 	for {
 		select {
 		case f := <-e.jobFunctions:
+			log.Println("running task")
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/executor.go
+++ b/executor.go
@@ -77,7 +77,7 @@ func (e *executor) start() {
 
 				switch f.runConfig.mode {
 				case defaultMode:
-					callJobFuncWithParams(f.functions[f.name], f.params[f.name])
+					callJobFuncWithParams(f.function, f.parameters)
 				case singletonMode:
 					_, _, _ = f.limiter.Do("main", func() (interface{}, error) {
 						select {
@@ -87,7 +87,7 @@ func (e *executor) start() {
 							return nil, nil
 						default:
 						}
-						callJobFuncWithParams(f.functions[f.name], f.params[f.name])
+						callJobFuncWithParams(f.function, f.parameters)
 						return nil, nil
 					})
 				}

--- a/executor.go
+++ b/executor.go
@@ -2,7 +2,6 @@ package gocron
 
 import (
 	"context"
-	"log"
 	"sync"
 
 	"golang.org/x/sync/semaphore"
@@ -46,7 +45,6 @@ func (e *executor) start() {
 	for {
 		select {
 		case f := <-e.jobFunctions:
-			log.Println("running task")
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/go-co-op/gocron
 go 1.16
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
-golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/gocron.go
+++ b/gocron.go
@@ -25,10 +25,11 @@ var (
 	ErrInvalidIntervalType           = errors.New(".Every() interval must be int, time.Duration, or string")
 	ErrInvalidIntervalUnitsSelection = errors.New("an .Every() duration interval cannot be used with units (e.g. .Seconds())")
 
-	ErrAtTimeNotSupported  = errors.New("the At() method is not supported for this time unit")
-	ErrWeekdayNotSupported = errors.New("weekday is not supported for time unit")
-	ErrTagsUnique          = func(tag string) error { return fmt.Errorf("a non-unique tag was set on the job: %s", tag) }
-	ErrWrongParams         = errors.New("wrong list of params")
+	ErrAtTimeNotSupported     = errors.New("the At() method is not supported for this time unit")
+	ErrWeekdayNotSupported    = errors.New("weekday is not supported for time unit")
+	ErrTagsUnique             = func(tag string) error { return fmt.Errorf("a non-unique tag was set on the job: %s", tag) }
+	ErrWrongParams            = errors.New("wrong list of params")
+	ErrUpdateCalledWithoutJob = errors.New("a call to Scheduler.Update() requires a call to Scheduler.Job() first")
 )
 
 func wrapOrError(toWrap error, err error) error {

--- a/job.go
+++ b/job.go
@@ -109,6 +109,30 @@ func (j *Job) setStartAtTime(t time.Time) {
 	j.startAtTime = t
 }
 
+func (j *Job) getUnit() timeUnit {
+	j.RLock()
+	defer j.RUnlock()
+	return j.unit
+}
+
+func (j *Job) setUnit(t timeUnit) {
+	j.Lock()
+	defer j.Unlock()
+	j.unit = t
+}
+
+func (j *Job) getDuration() time.Duration {
+	j.RLock()
+	defer j.RUnlock()
+	return j.duration
+}
+
+func (j *Job) setDuration(t time.Duration) {
+	j.Lock()
+	defer j.Unlock()
+	j.duration = t
+}
+
 // Error returns an error if one occurred while creating the Job.
 // If multiple errors occurred, they will be wrapped and can be
 // checked using the standard unwrap options.

--- a/job.go
+++ b/job.go
@@ -26,17 +26,17 @@ type Job struct {
 	dayOfTheMonth     int           // Specific day of the month to run the job
 	tags              []string      // allow the user to tag Jobs with certain labels
 	runCount          int           // number of times the job ran
-	timer             *time.Timer
+	timer             *time.Timer   // handles running tasks at specific time
 }
 
 type jobFunction struct {
-	functions map[string]interface{}   // Map for the function task store
-	params    map[string][]interface{} // Map for function and params of function
-	name      string                   // the Job name to run, func[jobFunc]
-	runConfig runConfig                // configuration for how many times to run the job
-	limiter   *singleflight.Group      // limits inflight runs of job to one
-	ctx       context.Context          // for cancellation
-	cancel    context.CancelFunc       // for cancellation
+	function   interface{}         // task's function
+	parameters []interface{}       // task's function parameters
+	name       string              // the function name to run
+	runConfig  runConfig           // configuration for how many times to run the job
+	limiter    *singleflight.Group // limits inflight runs of job to one
+	ctx        context.Context     // for cancellation
+	cancel     context.CancelFunc  // for cancellation
 }
 
 type runConfig struct {
@@ -65,10 +65,8 @@ func NewJob(interval int) *Job {
 		lastRun:  time.Time{},
 		nextRun:  time.Time{},
 		jobFunction: jobFunction{
-			functions: make(map[string]interface{}),
-			params:    make(map[string][]interface{}),
-			ctx:       ctx,
-			cancel:    cancel,
+			ctx:    ctx,
+			cancel: cancel,
 		},
 		tags:              []string{},
 		startsImmediately: true,

--- a/job.go
+++ b/job.go
@@ -32,7 +32,7 @@ type Job struct {
 type jobFunction struct {
 	function   interface{}         // task's function
 	parameters []interface{}       // task's function parameters
-	name       string              // the function name to run
+	name       string              //nolint the function name to run
 	runConfig  runConfig           // configuration for how many times to run the job
 	limiter    *singleflight.Group // limits inflight runs of job to one
 	ctx        context.Context     // for cancellation

--- a/job.go
+++ b/job.go
@@ -221,10 +221,11 @@ func (j *Job) RunCount() int {
 	return j.runCount
 }
 
-func (j *Job) stopTimer() {
+func (j *Job) stop() {
 	j.Lock()
 	defer j.Unlock()
 	if j.timer != nil {
 		j.timer.Stop()
 	}
+	j.cancel()
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -806,5 +806,5 @@ func (s *Scheduler) Update() (*Job, error) {
 		return j, wrapOrError(j.error, ErrUpdateCalledWithoutJob)
 	}
 	j.stop()
-	return s.Do(j.function, j.parameters)
+	return s.Do(j.function, j.parameters...)
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -561,9 +561,9 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 	}
 
 	fname := getFunctionName(jobFun)
-	if _, ok := job.functions[fname]; !ok {
-		job.functions[fname] = jobFun
-		job.params[fname] = params
+	if job.name != fname {
+		job.function = jobFun
+		job.parameters = params
 		job.name = fname
 	}
 
@@ -806,5 +806,5 @@ func (s *Scheduler) Update() (*Job, error) {
 		return j, wrapOrError(j.error, ErrUpdateCalledWithoutJob)
 	}
 	j.stop()
-	return s.Do(j.functions[j.name], j.params[j.name]...)
+	return s.Do(j.function, j.parameters)
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -794,5 +794,5 @@ func (s *Scheduler) Job(j *Job) *Scheduler {
 func (s *Scheduler) Update() (*Job, error) {
 	j := s.getCurrentJob()
 	j.stop()
-	return s.Do(j.functions[j.name], j.params)
+	return s.Do(j.functions[j.name], j.params[j.name]...)
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3,7 +3,6 @@ package gocron
 import (
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -56,7 +55,7 @@ func TestImmediateExecution(t *testing.T) {
 
 }
 
-func TestInvalidEveryInterval(t *testing.T) {
+func TestScheduler_Every_InvalidInterval(t *testing.T) {
 	testCases := []struct {
 		description   string
 		interval      interface{}
@@ -64,7 +63,7 @@ func TestInvalidEveryInterval(t *testing.T) {
 	}{
 		{"zero", 0, ErrInvalidInterval.Error()},
 		{"negative", -1, ErrInvalidInterval.Error()},
-		{"invalid string duration", "bad", "time: invalid duration"},
+		{"invalid string duration", "bad", "time: invalid duration \"bad\""},
 	}
 
 	s := NewScheduler(time.UTC)
@@ -73,9 +72,7 @@ func TestInvalidEveryInterval(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			_, err := s.Every(tc.interval).Do(func() {})
 			require.Error(t, err)
-			// wonky way to assert on the error message, but between go 1.14
-			// and go 1.15 the error value was wrapped in quotes
-			assert.True(t, strings.HasPrefix(err.Error(), tc.expectedError))
+			assert.EqualError(t, err, tc.expectedError)
 		})
 	}
 
@@ -109,7 +106,7 @@ func TestScheduler_Every(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		semaphore := make(chan bool)
 
-		_, err := s.Every(1).Second().Do(func() {
+		_, err := s.Every(100).Milliseconds().Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
@@ -119,7 +116,7 @@ func TestScheduler_Every(t *testing.T) {
 		var counter int
 
 		now := time.Now()
-		for time.Now().Before(now.Add(1 * time.Second)) {
+		for time.Now().Before(now.Add(100 * time.Millisecond)) {
 			if <-semaphore {
 				counter++
 			}
@@ -132,7 +129,7 @@ func TestScheduler_Every(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		semaphore := make(chan bool)
 
-		_, err := s.Every("1s").Do(func() {
+		_, err := s.Every("100ms").Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
@@ -142,7 +139,7 @@ func TestScheduler_Every(t *testing.T) {
 		var counter int
 
 		now := time.Now()
-		for time.Now().Before(now.Add(1 * time.Second)) {
+		for time.Now().Before(now.Add(100 * time.Millisecond)) {
 			if <-semaphore {
 				counter++
 			}
@@ -150,6 +147,7 @@ func TestScheduler_Every(t *testing.T) {
 		s.Stop()
 		assert.Equal(t, 2, counter)
 	})
+
 }
 
 func TestExecutionSeconds(t *testing.T) {
@@ -158,12 +156,12 @@ func TestExecutionSeconds(t *testing.T) {
 
 	var (
 		executions         []int64
-		interval           = 2
-		expectedExecutions = 4
+		interval           = 1
+		expectedExecutions = 2
 		mu                 sync.RWMutex
 	)
 
-	runTime := 6 * time.Second
+	runTime := 1 * time.Second
 	startTime := time.Now()
 
 	// default unit is seconds
@@ -348,17 +346,17 @@ func TestScheduler_Remove(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		semaphore := make(chan bool)
 
-		j, err := s.Every(1).Seconds().StartAt(s.time.Now(s.location).Add(time.Second)).Do(func() {
+		j, err := s.Every("100ms").StartAt(s.time.Now(s.location).Add(time.Second)).Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
 
 		s.StartAsync()
 
-		s.Remove(j.functions[j.name])
+		s.Remove(j.function)
 
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(200 * time.Millisecond):
 			// test passed
 		case <-semaphore:
 			t.Fatal("job ran after being removed")
@@ -382,7 +380,7 @@ func TestScheduler_RemoveByReference(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		semaphore := make(chan bool)
 
-		j, err := s.Every(1).Seconds().StartAt(s.time.Now(s.location).Add(time.Second)).Do(func() {
+		j, err := s.Every("100ms").StartAt(s.time.Now(s.location).Add(100 * time.Millisecond)).Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
@@ -392,7 +390,7 @@ func TestScheduler_RemoveByReference(t *testing.T) {
 		s.RemoveByReference(j)
 
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(200 * time.Millisecond):
 			// test passed
 		case <-semaphore:
 			t.Fatal("job ran after being removed")
@@ -488,7 +486,7 @@ func TestClear(t *testing.T) {
 	s := NewScheduler(time.UTC)
 	semaphore := make(chan bool)
 
-	_, err := s.Every(1).Second().Do(func() {
+	_, err := s.Every("100ms").Do(func() {
 		semaphore <- true
 	})
 	require.NoError(t, err)
@@ -500,7 +498,7 @@ func TestClear(t *testing.T) {
 
 	var counter int
 	now := time.Now()
-	for time.Now().Before(now.Add(1 * time.Second)) {
+	for time.Now().Before(now.Add(200 * time.Millisecond)) {
 		select {
 		case <-semaphore:
 			counter++
@@ -592,14 +590,14 @@ func TestScheduler_StartAt(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		semaphore := make(chan bool)
 
-		s.Every(1).Day().StartAt(s.time.Now(s.location).Add(time.Second)).Do(func() {
+		s.Every(1).Day().StartAt(s.time.Now(s.location).Add(100 * time.Millisecond)).Do(func() {
 			semaphore <- true
 		})
 
 		s.StartAsync()
 
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(200 * time.Millisecond):
 			t.Fatal("job did not run at 1 second")
 		case <-semaphore:
 			// test passed
@@ -762,18 +760,18 @@ func TestRunJobsWithLimit(t *testing.T) {
 
 		s := NewScheduler(time.UTC)
 
-		j, err := s.Every(1).Second().Do(func() {
+		j, err := s.Every("100ms").Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
 		j.LimitRunsTo(1)
 
 		s.StartAsync()
-		time.Sleep(2 * time.Second)
+		time.Sleep(200 * time.Millisecond)
 
 		var counter int
 		now := time.Now()
-		for time.Now().Before(now.Add(2 * time.Second)) {
+		for time.Now().Before(now.Add(200 * time.Millisecond)) {
 			select {
 			case <-semaphore:
 				counter++
@@ -789,18 +787,18 @@ func TestRunJobsWithLimit(t *testing.T) {
 
 		s := NewScheduler(time.UTC)
 
-		j, err := s.Every(1).Second().Do(func() {
+		j, err := s.Every("100ms").Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
 		j.LimitRunsTo(1)
 
 		s.StartAsync()
-		time.Sleep(2 * time.Second)
+		time.Sleep(200 * time.Millisecond)
 
 		var counter int
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(200 * time.Millisecond):
 			assert.Equal(t, 0, s.Len())
 		case <-semaphore:
 			counter++
@@ -841,21 +839,21 @@ func TestScheduler_SingletonMode(t *testing.T) {
 			s := NewScheduler(time.UTC)
 			var trigger int32
 
-			j, err := s.Every(1).Second().SingletonMode().Do(func() {
+			j, err := s.Every("100ms").SingletonMode().Do(func() {
 				if atomic.LoadInt32(&trigger) == 1 {
 					t.Fatal("Restart should not occur")
 				}
 				atomic.AddInt32(&trigger, 1)
-				time.Sleep(3 * time.Second)
+				time.Sleep(300 * time.Millisecond)
 			})
 			require.NoError(t, err)
 
 			s.StartAsync()
-			time.Sleep(2 * time.Second)
+			time.Sleep(200 * time.Millisecond)
 
 			if tc.removeJob {
 				s.RemoveByReference(j)
-				time.Sleep(3 * time.Second)
+				time.Sleep(300 * time.Millisecond)
 			}
 			s.Stop()
 		})
@@ -869,17 +867,17 @@ func TestScheduler_LimitRunsTo(t *testing.T) {
 
 		s := NewScheduler(time.UTC)
 
-		_, err := s.Every(1).Second().LimitRunsTo(1).Do(func() {
+		_, err := s.Every("100ms").LimitRunsTo(1).Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
 
 		s.StartAsync()
-		time.Sleep(2 * time.Second)
+		time.Sleep(200 * time.Millisecond)
 
 		var counter int
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(200 * time.Millisecond):
 			assert.Equal(t, 1, counter)
 		case <-semaphore:
 			counter++
@@ -893,16 +891,16 @@ func TestScheduler_LimitRunsTo(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		s.StartAsync()
 
-		_, err := s.Every(1).Second().LimitRunsTo(1).Do(func() {
+		_, err := s.Every("100ms").LimitRunsTo(1).Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(200 * time.Millisecond)
 
 		var counter int
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(200 * time.Millisecond):
 			assert.Equal(t, 1, counter)
 		case <-semaphore:
 			counter++
@@ -916,17 +914,17 @@ func TestScheduler_LimitRunsTo(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		s.StartAsync()
 
-		j, err := s.Every(1).Second().Do(func() {
+		j, err := s.Every("100ms").Do(func() {
 			semaphore <- true
 		})
 		require.NoError(t, err)
 		j.LimitRunsTo(1)
 
-		time.Sleep(2 * time.Second)
+		time.Sleep(200 * time.Millisecond)
 
 		var counter int
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(200 * time.Millisecond):
 			assert.Equal(t, 2, counter)
 		case <-semaphore:
 			counter++
@@ -954,7 +952,7 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 		{"reschedule mode", 2, RescheduleMode, 4, false,
 			func() {
 				semaphore <- true
-				time.Sleep(2 * time.Second)
+				time.Sleep(200 * time.Millisecond)
 			},
 		},
 
@@ -966,7 +964,7 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 		{"wait mode", 2, WaitMode, 8, false,
 			func() {
 				semaphore <- true
-				time.Sleep(1 * time.Second)
+				time.Sleep(100 * time.Millisecond)
 			},
 		},
 
@@ -974,7 +972,7 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 		{"wait mode - with job removal", 2, WaitMode, 8, true,
 			func() {
 				semaphore <- true
-				time.Sleep(1 * time.Second)
+				time.Sleep(100 * time.Millisecond)
 			},
 		},
 	}
@@ -985,13 +983,13 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 			s := NewScheduler(time.UTC)
 			s.SetMaxConcurrentJobs(tc.maxConcurrentJobs, tc.mode)
 
-			j1, err := s.Every(1).Second().Do(tc.f)
+			j1, err := s.Every("100ms").Do(tc.f)
 			require.NoError(t, err)
 
-			j2, err := s.Every(2).Second().Do(tc.f)
+			j2, err := s.Every("200ms").Do(tc.f)
 			require.NoError(t, err)
 
-			j3, err := s.Every(3).Second().Do(tc.f)
+			j3, err := s.Every("300ms").Do(tc.f)
 			require.NoError(t, err)
 
 			s.StartAsync()
@@ -999,7 +997,7 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 			var counter int
 
 			now := time.Now()
-			for time.Now().Before(now.Add(4 * time.Second)) {
+			for time.Now().Before(now.Add(400 * time.Millisecond)) {
 				select {
 				case <-semaphore:
 					counter++
@@ -1020,7 +1018,7 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 			// or job should be properly stopped
 
 			now = time.Now()
-			for time.Now().Before(now.Add(1 * time.Second)) {
+			for time.Now().Before(now.Add(200 * time.Millisecond)) {
 				select {
 				case <-semaphore:
 					counter++


### PR DESCRIPTION
### What does this do?

- Adds support for rescheduling jobs using the following syntax:
    ```golang
	func ExampleScheduler_Update() {
		s := gocron.NewScheduler(time.UTC)
		j, _ := s.Every("1s").Do(func() {})
	
		time.Sleep(10 * time.Second)
		j, _ = s.Job(j).Every("10m").Update()
	
		time.Sleep(30 * time.Minute)
		_, _ = s.Job(j).Every(1).Day().At("02:00").Update()
	}
    ```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
#72 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
