### PR TITLE
Run jobs by Tag

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -617,3 +617,19 @@ func ExampleScheduler_Weeks() {
 	_, _ = s.Every(1).Week().Do(task)
 	_, _ = s.Every(1).Weeks().Do(task)
 }
+
+func ExampleScheduler_RunByTag() {
+	s := gocron.NewScheduler(time.UTC)
+	_, _ = s.Every(1).Day().At("10:00").Do(task)
+	_, _ = s.Every(2).Day().Tag("tag").At("10:00").Do(task)
+	s.StartAsync()
+	s.RunByTag("tag")
+}
+
+func ExampleScheduler_RunByTagWithDelay() {
+	s := gocron.NewScheduler(time.UTC)
+	_, _ = s.Every(1).Day().Tag("tag").At("10:00").Do(task)
+	_, _ = s.Every(2).Day().Tag("tag").At("10:00").Do(task)
+	s.StartAsync()
+	s.RunByTagWithDelay("tag", 2*time.Second)
+}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1135,3 +1135,23 @@ func TestScheduler_Update(t *testing.T) {
 		assert.EqualError(t, err, ErrUpdateCalledWithoutJob.Error())
 	})
 }
+
+func TestScheduler_RunByTag(t *testing.T) {
+	var (
+		s     = NewScheduler(time.Local)
+		count = 0
+		wg    sync.WaitGroup
+	)
+
+	s.Every(1).Day().StartAt(time.Now().Add(time.Hour)).Tag("tag").Do(func() {
+		count++
+		wg.Done()
+	})
+	wg.Add(1)
+	s.StartAsync()
+	assert.NoError(t, s.RunByTag("tag"))
+
+	wg.Wait()
+	assert.Equal(t, 1, count)
+	assert.Error(t, s.RunByTag("wrong-tag"))
+}


### PR DESCRIPTION
### What does this do?

Add 2 new functions to Scheduler
  * `RunByTag` - Run all jobs that have a specific tag
  * `RunByTagWithDelay` - Run all jobs that have a specific tag with a
  delay in between executions

Fix: `RemoveByTag` function should remove all jobs with the given tag. Not
just the first job encountered

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves #143


### List any changes that modify/break current functionality

As mentioned above, currently, `RunByTag` only deletes the first job it finds with a given tag. But this PR modifies that behavior to delete all the jobs with the given tag.

### Have you included tests for your changes?

Yes

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`