### PR TITLE
fix lastRun not being set properly in schedule next run & crontabs should not start immediately

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -151,6 +151,7 @@ func (s *Scheduler) scheduleNextRun(job *Job) {
 
 	if job.getStartsImmediately() {
 		s.run(job)
+		lastRun = now
 		job.setStartsImmediately(false)
 	}
 
@@ -840,6 +841,7 @@ func (s *Scheduler) Cron(c string) *Scheduler {
 
 	job.cronSchedule = cronSchedule
 	job.unit = crontab
+	job.startsImmediately = false
 
 	s.setJobs(append(s.Jobs(), job))
 	return s

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1158,6 +1158,7 @@ func TestScheduler_RunByTag(t *testing.T) {
 
 func TestScheduler_Cron(t *testing.T) {
 	ft := fakeTime{onNow: func(l *time.Location) time.Time {
+		// January 1st, 12 noon, Thursday, 1970
 		return time.Date(1970, 1, 1, 12, 0, 0, 0, l)
 	}}
 
@@ -1175,6 +1176,8 @@ func TestScheduler_Cron(t *testing.T) {
 		{"every day 1am", "0 1 * * *", ft.onNow(time.UTC).Add(13 * time.Hour), nil},
 		{"weekends only", "0 0 * * 6,0", ft.onNow(time.UTC).Add(36 * time.Hour), nil},
 		{"at time monday thru friday", "0 22 * * 1-5", ft.onNow(time.UTC).Add(10 * time.Hour), nil},
+		{"every minute in range, monday thru friday", "15-30 * * * 1-5", ft.onNow(time.UTC).Add(15 * time.Minute), nil},
+		{"at every minute past every hour from 1 through 5 on every day-of-week from Monday through Friday.", "* 1-5 * * 1-5", ft.onNow(time.UTC).Add(13 * time.Hour), nil},
 		{"hourly", "@hourly", ft.onNow(time.UTC).Add(1 * time.Hour), nil},
 		{"bad expression", "bad", time.Time{}, wrapOrError(fmt.Errorf("expected exactly 5 fields, found 1: [bad]"), ErrCronParseFailure)},
 	}


### PR DESCRIPTION
### What does this do?

- The lastRun time was not being set inside the schedule run function after we run the job (in the case of a job starting immediately).
- crontabs run on the minute, or hour, etc. so we don't want them to start immediately

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
fixes https://github.com/go-co-op/gocron/issues/153

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
