### PR TITLE
handle occasional occurence of double run on daily job

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -257,12 +257,12 @@ func (s *Scheduler) calculateTotalDaysDifference(lastRun time.Time, daysToWeekda
 }
 
 func (s *Scheduler) calculateDays(job *Job, lastRun time.Time) time.Duration {
-	// handle occasional occurrence of job running to quickly / too early such that last run was within a second of now
-	lastRunUnix, nowUnix := job.LastRun().Unix(), s.time.Now(s.location).Unix()
 
 	if job.interval == 1 {
 		lastRunDayPlusJobAtTime := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day(), 0, 0, 0, 0, s.Location()).Add(job.getAtTime())
 
+		// handle occasional occurrence of job running to quickly / too early such that last run was within a second of now
+		lastRunUnix, nowUnix := job.LastRun().Unix(), s.time.Now(s.location).Unix()
 		if lastRunUnix == nowUnix || lastRunUnix == nowUnix-1 || lastRunUnix == nowUnix+1 {
 			lastRun = lastRunDayPlusJobAtTime
 		}

--- a/scheduler.go
+++ b/scheduler.go
@@ -263,7 +263,7 @@ func (s *Scheduler) calculateDays(job *Job, lastRun time.Time) time.Duration {
 		lastRunDayPlusJobAtTime := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day(), 0, 0, 0, 0, s.Location()).Add(job.getAtTime())
 
 		// handle occasional occurrence of job running to quickly / too early such that last run was within a second of now
-		lastRunUnix, nowUnix := job.LastRun().Unix(), s.time.Now(s.location).Unix()
+		lastRunUnix, nowUnix := job.LastRun().Unix(), s.now().Unix()
 		if lastRunUnix == nowUnix || lastRunUnix == nowUnix-1 || lastRunUnix == nowUnix+1 {
 			lastRun = lastRunDayPlusJobAtTime
 		}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -228,6 +228,8 @@ func TestAt(t *testing.T) {
 
 		select {
 		case <-time.After(1 * time.Second):
+			log.Println(now.Add(time.Minute))
+			log.Println(dayJob.nextRun)
 			assert.Equal(t, now.Add(1*time.Minute), dayJob.nextRun)
 		case <-semaphore:
 			t.Fatal("job ran even though scheduled in future")


### PR DESCRIPTION
### What does this do?

we see an occasional instance of a daily job running twice within a second. this seems to be due to the job running too fast and starting a fraction of a second early such that it runs during the 1 second window before it should. this fix handles that case for daily jobs as those only run once at a given even hour/min/sec time.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->

https://github.com/go-co-op/gocron/issues/52#issuecomment-816502678

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
