### PR TITLE
clear the job context for singleton on update

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -1,6 +1,7 @@
 package gocron
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"reflect"
@@ -829,6 +830,7 @@ func (s *Scheduler) Update() (*Job, error) {
 		return job, wrapOrError(job.error, ErrUpdateCalledWithoutJob)
 	}
 	job.stop()
+	job.ctx, job.cancel = context.WithCancel(context.Background())
 	return s.Do(job.function, job.parameters...)
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1126,6 +1126,33 @@ func TestScheduler_Update(t *testing.T) {
 		assert.Equal(t, 3, counter)
 	})
 
+	t.Run("happy singleton mode", func(t *testing.T) {
+		s := NewScheduler(time.UTC)
+
+		var counterMutex sync.RWMutex
+		counter := 0
+
+		j, err := s.Every(1).Day().SingletonMode().Do(func() { counterMutex.Lock(); defer counterMutex.Unlock(); counter++ })
+		require.NoError(t, err)
+
+		s.StartAsync()
+
+		time.Sleep(300 * time.Millisecond)
+		_, err = s.Job(j).Every("500ms").Update()
+		require.NoError(t, err)
+
+		time.Sleep(550 * time.Millisecond)
+		_, err = s.Job(j).Every("750ms").Update()
+		require.NoError(t, err)
+
+		time.Sleep(800 * time.Millisecond)
+		s.Stop()
+
+		counterMutex.RLock()
+		defer counterMutex.RUnlock()
+		assert.Equal(t, 3, counter)
+	})
+
 	t.Run("update called with job call", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
 		_, err := s.Every("1s").Do(func() {})


### PR DESCRIPTION
### What does this do?

singleton jobs as well as waitmode jobs listen for the job context to be cancelled. `Update()` needs to clear that otherwise all subsequent runs are skipped because the context.Done() check is always true.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #157 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
