### PR TITLE
add WaitForSchedule(s) funcs

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -596,7 +596,7 @@ func ExampleScheduler_Tuesday() {
 
 func ExampleScheduler_Update() {
 	s := gocron.NewScheduler(time.UTC)
-	j, _ := s.Every("1s").Do(func() {})
+	j, _ := s.Every("1s").Do(task)
 	s.StartAsync()
 
 	time.Sleep(10 * time.Second)
@@ -604,6 +604,27 @@ func ExampleScheduler_Update() {
 
 	time.Sleep(30 * time.Minute)
 	_, _ = s.Job(j).Every(1).Day().At("02:00").Update()
+}
+
+func ExampleScheduler_WaitForSchedule() {
+	s := gocron.NewScheduler(time.UTC)
+
+	// job will run 5 minutes from the scheduler starting
+	_, _ = s.Every("5m").WaitForSchedule().Do(task)
+
+	// job will run immediately and 5 minutes from the scheduler starting
+	_, _ = s.Every("5m").Do(task)
+	s.StartAsync()
+}
+
+func ExampleScheduler_WaitForSchedules() {
+	s := gocron.NewScheduler(time.UTC)
+	s.WaitForSchedules()
+
+	// all jobs will run 5 minutes from the scheduler starting
+	_, _ = s.Every("5m").Do(task)
+	_, _ = s.Every("5m").Do(task)
+	s.StartAsync()
 }
 
 func ExampleScheduler_Wednesday() {

--- a/example_test.go
+++ b/example_test.go
@@ -619,7 +619,7 @@ func ExampleScheduler_WaitForSchedule() {
 
 func ExampleScheduler_WaitForSchedules() {
 	s := gocron.NewScheduler(time.UTC)
-	s.WaitForSchedules()
+	s.WaitForScheduleAll()
 
 	// all jobs will run 5 minutes from the scheduler starting
 	_, _ = s.Every("5m").Do(task)

--- a/example_test.go
+++ b/example_test.go
@@ -617,7 +617,7 @@ func ExampleScheduler_WaitForSchedule() {
 	s.StartAsync()
 }
 
-func ExampleScheduler_WaitForSchedules() {
+func ExampleScheduler_WaitForScheduleAll() {
 	s := gocron.NewScheduler(time.UTC)
 	s.WaitForScheduleAll()
 

--- a/job.go
+++ b/job.go
@@ -58,8 +58,8 @@ const (
 	singletonMode
 )
 
-// NewJob creates a new Job with the provided interval
-func NewJob(interval int) *Job {
+// newJob creates a new Job with the provided interval
+func newJob(interval int, startImmediately bool) *Job {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Job{
 		interval: interval,
@@ -71,7 +71,7 @@ func NewJob(interval int) *Job {
 			cancel: cancel,
 		},
 		tags:              []string{},
-		startsImmediately: true,
+		startsImmediately: startImmediately,
 	}
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -884,11 +884,11 @@ func (s *Scheduler) newJob(interval int) *Job {
 	return newJob(interval, !s.waitForInterval)
 }
 
-// WaitForSchedules defaults the scheduler to create all
+// WaitForScheduleAll defaults the scheduler to create all
 // new jobs with the WaitForSchedule option as true.
 // The jobs will not start immediately but rather will
 // wait until their first scheduled interval.
-func (s *Scheduler) WaitForSchedules() {
+func (s *Scheduler) WaitForScheduleAll() {
 	s.waitForInterval = true
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -881,10 +881,7 @@ func (s *Scheduler) cron(cronExpression string, withSeconds bool) *Scheduler {
 }
 
 func (s *Scheduler) newJob(interval int) *Job {
-	if s.waitForInterval {
-		return newJob(interval, false)
-	}
-	return newJob(interval, true)
+	return newJob(interval, !s.waitForInterval)
 }
 
 // WaitForSchedules defaults the scheduler to create all

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1317,7 +1317,7 @@ func TestScheduler_WaitForSchedule(t *testing.T) {
 
 func TestScheduler_WaitForSchedules(t *testing.T) {
 	s := NewScheduler(time.UTC)
-	s.WaitForSchedules()
+	s.WaitForScheduleAll()
 
 	var counterMutex sync.RWMutex
 	counter := 0


### PR DESCRIPTION
### What does this do?
- adds `WaitForSchedule` and `WaitForSchedules` to allow setting per job or for all jobs to wait for the first scheduled run rather than running immediately
- un-exports the job's `NewJob` method. There was no use for it to be exported as we don't accept a newly created job struct in any scheduler methods. alters the signature to handle the wait for interval logic

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
#152 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
