### PR TITLE
fixing invalid test behavior

### DIFF
--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1424,9 +1424,6 @@ func TestScheduler_CheckNextWeekDay(t *testing.T) {
 		gotFirst := s.durationToNextRun(lastRun, job)
 		assert.Equal(t, wantTimeUntilNextFirstRun, gotFirst)
 
-		s.StartAsync()
-		time.Sleep(1 * time.Second)
-
 		job.lastRun = secondLastRun
 		gotSecond := s.durationToNextRun(secondLastRun, job)
 		assert.Equal(t, wantTimeUntilNextSecondRun, gotSecond)


### PR DESCRIPTION
### What does this do?

Fix invalid test behavior that allows race conditions to happen. 

to test: `go test -race -v -count=2 -run ^TestScheduler_CheckNextWeekDay`
### Which issue(s) does this PR fix/relate to?


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
