### PR TITLE
Fix calculatemonths()

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -3,7 +3,6 @@ package gocron
 import (
 	"context"
 	"fmt"
-	"math"
 	"reflect"
 	"sort"
 	"strings"
@@ -213,16 +212,18 @@ func (s *Scheduler) calculateMonths(job *Job, lastRun time.Time) time.Duration {
 
 	if job.dayOfTheMonth > 0 { // calculate days to job.dayOfTheMonth
 		jobDay := time.Date(lastRun.Year(), lastRun.Month(), job.dayOfTheMonth, 0, 0, 0, 0, s.Location()).Add(job.getAtTime())
-		daysDifference := int(math.Abs(lastRun.Sub(jobDay).Hours()) / 24)
-		nextRun := s.roundToMidnight(lastRun).Add(job.getAtTime())
+		hourDifference := absDuration(lastRun.Sub(jobDay))
+		nextRun := lastRun
 		if jobDay.Before(lastRun) { // shouldn't run this month; schedule for next interval minus day difference
-			nextRun = nextRun.AddDate(0, job.interval, -daysDifference)
+			nextRun = nextRun.AddDate(0, job.interval, -0)
+			nextRun = nextRun.Add(-hourDifference)
 		} else {
 			if job.interval == 1 { // every month counts current month
-				nextRun = nextRun.AddDate(0, job.interval-1, daysDifference)
+				nextRun = nextRun.AddDate(0, job.interval-1, 0)
 			} else { // should run next month interval
-				nextRun = nextRun.AddDate(0, job.interval, daysDifference)
+				nextRun = nextRun.AddDate(0, job.interval, 0)
 			}
+			nextRun = nextRun.Add(hourDifference)
 		}
 		return until(lastRun, nextRun)
 	}
@@ -349,6 +350,14 @@ func remainingDaysToWeekday(from time.Weekday, weekDays []time.Weekday) int {
 		}
 	}
 	return daysUntilScheduledDay
+}
+
+// absDuration returns the abs time difference
+func absDuration(a time.Duration) time.Duration {
+	if a >= 0 {
+		return a
+	}
+	return -a
 }
 
 // roundToMidnight truncates time to midnight

--- a/scheduler.go
+++ b/scheduler.go
@@ -212,18 +212,18 @@ func (s *Scheduler) calculateMonths(job *Job, lastRun time.Time) time.Duration {
 
 	if job.dayOfTheMonth > 0 { // calculate days to job.dayOfTheMonth
 		jobDay := time.Date(lastRun.Year(), lastRun.Month(), job.dayOfTheMonth, 0, 0, 0, 0, s.Location()).Add(job.getAtTime())
-		hourDifference := absDuration(lastRun.Sub(jobDay))
+		difference := absDuration(lastRun.Sub(jobDay))
 		nextRun := lastRun
 		if jobDay.Before(lastRun) { // shouldn't run this month; schedule for next interval minus day difference
 			nextRun = nextRun.AddDate(0, job.interval, -0)
-			nextRun = nextRun.Add(-hourDifference)
+			nextRun = nextRun.Add(-difference)
 		} else {
 			if job.interval == 1 { // every month counts current month
 				nextRun = nextRun.AddDate(0, job.interval-1, 0)
 			} else { // should run next month interval
 				nextRun = nextRun.AddDate(0, job.interval, 0)
 			}
-			nextRun = nextRun.Add(hourDifference)
+			nextRun = nextRun.Add(difference)
 		}
 		return until(lastRun, nextRun)
 	}


### PR DESCRIPTION
### What does this do?
Switches to using raw duration from a day-clamped duration for the difference between lastRun and jobDay.

### Which issue(s) does this PR fix/relate to?
Resolves #172


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
