### PR TITLE
Delete unique tag alongside RemoveByTag

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -528,6 +528,10 @@ func (s *Scheduler) RemoveByTag(tag string) error {
 	if err != nil {
 		return err
 	}
+
+	// Remove unique tag when exists
+	delete(s.tags, tag)
+
 	for _, job := range jobs {
 		s.RemoveByReference(job)
 	}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -444,7 +444,7 @@ func TestScheduler_RemoveByTag(t *testing.T) {
 
 		// Adding job with tag after removing by tag, assuming the unique tag has been removed as well
 		_, err = s.Every(1).Second().Tag(tag1).Do(taskWithParams, 1, "hello")
-		assert.Equal(t, err, nil, "Unique tag is not deleted when removing by tag")
+		assert.Nil(t, err, "Unique tag is not deleted when removing by tag")
 	})
 }
 


### PR DESCRIPTION
### What does this do?
Currently, when you create jobs with unique tags and delete by tag afterwards, the unique tag is deleted. This leads to a unique tag constraint when adding a new job with the previous unique tag.

This PR solves this issue by deleting the unique tag alongside the `RemoveByTag` method.

### List any changes that modify/break current functionality
Delete unique tag in `RemoveByTag`

### Have you included tests for your changes?
yes

### Notes
Thanks for maintaining this library. We're planning to integrate it for a major feature and the tagging functionality is a game-changer :)
