### PR TITLE
Clear: remove also tags from scheduler

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -600,6 +600,9 @@ func (s *Scheduler) Clear() {
 		job.stop()
 	}
 	s.setJobs(make([]*Job, 0))
+	if s.tags != nil {
+		s.TagsUnique()
+	}
 }
 
 // Stop stops the scheduler. This is a no-op if the scheduler is already stopped .


### PR DESCRIPTION
### What does this do?
If scheduler is started with `TagsUnique()`, tags are cleared also after Clear.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?
No.

### Did you document any new/modified functionality?

No. It's bug fix.

### Notes
