### PR TITLE
handle creating a job after an update and delete

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -918,6 +918,7 @@ func (s *Scheduler) Update() (*Job, error) {
 	if !s.updateJob {
 		return job, wrapOrError(job.error, ErrUpdateCalledWithoutJob)
 	}
+	s.updateJob = false
 	job.stop()
 	job.ctx, job.cancel = context.WithCancel(context.Background())
 	return s.Do(job.function, job.parameters...)


### PR DESCRIPTION
### What does this do?
after a job was updated, we didn't clear the update flag on the scheduler which caused a nil pointer exception on the creation of a new job

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves https://github.com/go-co-op/gocron/issues/193

### List any changes that modify/break current functionality


### Have you included tests for your changes?
👍 

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
