### PR TITLE
Fix unique tag removal

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,7 +18,7 @@ linters:
     - deadcode
     - errcheck
     - gofmt
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet

--- a/job.go
+++ b/job.go
@@ -195,10 +195,9 @@ func (j *Job) Weekdays() []time.Weekday {
 	return j.scheduledWeekday
 }
 
-// 	return j.scheduledWeekday
-// }
 // LimitRunsTo limits the number of executions of this job to n.
-// The job will remain in the scheduler.
+// Upon reaching the limit, the job is removed from the scheduler.
+//
 // Note: If a job is added to a running scheduler and this method is then used
 // you may see the job run more than the set limit as job is scheduled immediately
 // by default upon being added to the scheduler. It is recommended to use the


### PR DESCRIPTION
### What does this do?

The remove functions have a bug where the unique tags set at the scheduler are only removed when using RemoveByTag which isn't used by the removal that occurs when the limit runs to is reached.

Updated the removal functions so that a check occurs to see if unique tags are being used and if so, remove all of the job's tags from the unique slice.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->

resolves https://github.com/go-co-op/gocron/issues/210

### List any changes that modify/break current functionality


### Have you included tests for your changes?
👍 

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
