### PR TITLE
catch time.AfterFunc firing early per wall clock time

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -8,12 +8,12 @@ import (
 )
 
 const (
-	// default is that if a limit on maximum concurrent jobs is set
-	// and the limit is reached, a job will skip it's run and try
-	// again on the next occurrence in the schedule
+	// RescheduleMode - the default is that if a limit on maximum
+	// concurrent jobs is set and the limit is reached, a job will
+	// skip it's run and try again on the next occurrence in the schedule
 	RescheduleMode limitMode = iota
 
-	// in wait mode if a limit on maximum concurrent jobs is set
+	// WaitMode - if a limit on maximum concurrent jobs is set
 	// and the limit is reached, a job will wait to try and run
 	// until a spot in the limit is freed up.
 	//

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -749,7 +749,7 @@ func TestScheduler_CalculateNextRun(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewScheduler(time.UTC)
 			s.time = ft
-			got := s.durationToNextRun(tc.job.LastRun(), tc.job)
+			got := s.durationToNextRun(tc.job.LastRun(), tc.job).duration
 			assert.Equalf(t, tc.wantTimeUntilNextRun, got, fmt.Sprintf("expected %s / got %s", tc.wantTimeUntilNextRun.String(), got.String()))
 		})
 	}
@@ -959,7 +959,7 @@ func TestCalculateMonths2(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			s := NewScheduler(time.UTC)
 			s.time = maySixth2021At0500
-			got := s.durationToNextRun(tc.job.LastRun(), tc.job)
+			got := s.durationToNextRun(tc.job.LastRun(), tc.job).duration
 			assert.Equalf(t, tc.wantTimeUntilNextRun, got, fmt.Sprintf("expected %s / got %s", tc.wantTimeUntilNextRun.String(), got.String()))
 		})
 	}
@@ -1493,10 +1493,10 @@ func TestScheduler_WaitForSchedules(t *testing.T) {
 	var counterMutex sync.RWMutex
 	counter := 0
 
-	_, err := s.Every("1s").Do(func() { counterMutex.Lock(); defer counterMutex.Unlock(); counter++ })
+	_, err := s.Every("1s").Do(func() { counterMutex.Lock(); defer counterMutex.Unlock(); counter++; log.Println("job 1") })
 	require.NoError(t, err)
 
-	_, err = s.CronWithSeconds("*/1 * * * * *").Do(func() { counterMutex.Lock(); defer counterMutex.Unlock(); counter++ })
+	_, err = s.CronWithSeconds("*/1 * * * * *").Do(func() { counterMutex.Lock(); defer counterMutex.Unlock(); counter++; log.Println("job 2") })
 	require.NoError(t, err)
 	s.StartAsync()
 
@@ -1565,7 +1565,7 @@ func TestScheduler_CallNextWeekDay(t *testing.T) {
 			require.NoError(t, err)
 			job.lastRun = lastRun
 
-			got := s.durationToNextRun(lastRun, job)
+			got := s.durationToNextRun(lastRun, job).duration
 			assert.Equal(t, wantTimeUntilNextRun, got)
 
 		})
@@ -1595,11 +1595,11 @@ func TestScheduler_CheckNextWeekDay(t *testing.T) {
 		require.NoError(t, err)
 		job.lastRun = lastRun
 
-		gotFirst := s.durationToNextRun(lastRun, job)
+		gotFirst := s.durationToNextRun(lastRun, job).duration
 		assert.Equal(t, wantTimeUntilNextFirstRun, gotFirst)
 
 		job.lastRun = secondLastRun
-		gotSecond := s.durationToNextRun(secondLastRun, job)
+		gotSecond := s.durationToNextRun(secondLastRun, job).duration
 		assert.Equal(t, wantTimeUntilNextSecondRun, gotSecond)
 
 	})
@@ -1646,7 +1646,7 @@ func TestScheduler_CheckEveryWeekHigherThanOne(t *testing.T) {
 				lastRun := januaryDay2020At(day)
 
 				job.lastRun = lastRun
-				got := s.durationToNextRun(lastRun, job)
+				got := s.durationToNextRun(lastRun, job).duration
 
 				if numJob < len(tc.weekDays) {
 					assert.Equal(t, wantTimeUntilNextRunOneDay, got)


### PR DESCRIPTION
### What does this do?

catches the case where a job expected to run at a specific wall clock time fires early due to wall and monotonic clocks being slightly out of sync - most commonly occurring in docker. 

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->

#52 #132

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
