### PR TITLE
Get current job every bug

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -643,6 +643,7 @@ func ExampleScheduler_WaitForSchedule() {
 
 	// job will run 5 minutes from the scheduler starting
 	_, _ = s.Every("5m").WaitForSchedule().Do(task)
+	_, _ = s.WaitForSchedule().Every("5m").Do(task)
 
 	// job will run immediately and 5 minutes from the scheduler starting
 	_, _ = s.Every("5m").Do(task)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1726,3 +1726,11 @@ func TestScheduler_CheckCalculateDaysOfMonth(t *testing.T) {
 		})
 	}
 }
+
+func TestScheduler_CheckSetWaitForSchedule(t *testing.T) {
+	s := NewScheduler(time.UTC)
+	s = s.WaitForSchedule().Every("1m")
+
+	assert.Equal(t, true, s.isWaitForSchedule)
+	assert.Equal(t, true, s.getCurrentJob().startsImmediately)
+}


### PR DESCRIPTION
### What does this do?
fix panic error and use WaitForSchedule method before new job created.

### Which issue(s) does this PR fix/relate to?
Resolve #230 


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
