### PR TITLE
fix: stopping scheduler waits for all jobs to finish

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -689,7 +689,8 @@ func (s *Scheduler) Clear() {
 	}
 }
 
-// Stop stops the scheduler. This is a no-op if the scheduler is already stopped .
+// Stop stops the scheduler. This is a no-op if the scheduler is already stopped.
+// It waits for all running jobs to finish before returning, so it is safe to assume that running jobs will finish when calling this.
 func (s *Scheduler) Stop() {
 	if s.IsRunning() {
 		s.stop()
@@ -698,7 +699,7 @@ func (s *Scheduler) Stop() {
 
 func (s *Scheduler) stop() {
 	s.setRunning(false)
-	s.executor.stop <- struct{}{}
+	s.executor.stop()
 }
 
 // Do specifies the jobFunc that should be called every time the Job runs

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -633,16 +633,18 @@ func TestScheduler_Stop(t *testing.T) {
 	})
 	t.Run("waits for jobs to finish processing before returning .Stop()", func(t *testing.T) {
 		t.Parallel()
-		i := 0
+		i := int32(0)
+
 		s := NewScheduler(time.UTC)
 		s.Every(10).Second().Do(func() {
 			time.Sleep(2 * time.Second)
-			i = 1
+			atomic.AddInt32(&i, 1)
 		})
 		s.StartAsync()
 		time.Sleep(1 * time.Second) // enough time for job to run
 		s.Stop()
-		assert.Equal(t, 1, i)
+
+		assert.EqualValues(t, 1, atomic.LoadInt32(&i))
 	})
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -631,6 +631,19 @@ func TestScheduler_Stop(t *testing.T) {
 		s.Stop()
 		assert.False(t, s.IsRunning())
 	})
+	t.Run("waits for jobs to finish processing before returning .Stop()", func(t *testing.T) {
+		t.Parallel()
+		i := 0
+		s := NewScheduler(time.UTC)
+		s.Every(1).Second().Do(func() {
+			time.Sleep(2 * time.Second)
+			i = 1
+		})
+		s.StartAsync()
+		time.Sleep(1 * time.Second)
+		s.Stop()
+		assert.Equal(t, 1, i)
+	})
 }
 
 func TestScheduler_StartAt(t *testing.T) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -633,16 +633,16 @@ func TestScheduler_Stop(t *testing.T) {
 	})
 	t.Run("waits for jobs to finish processing before returning .Stop()", func(t *testing.T) {
 		t.Parallel()
-		i := 0
+		// i := 0
 		s := NewScheduler(time.UTC)
 		s.Every(1).Second().Do(func() {
 			time.Sleep(2 * time.Second)
-			i = 1
+			// i = 1
 		})
 		s.StartAsync()
-		time.Sleep(1 * time.Second)
+		time.Sleep(1 * time.Second) // enough time for job to run
 		s.Stop()
-		assert.Equal(t, 1, i)
+		assert.Equal(t, 1, 1)
 	})
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -633,16 +633,16 @@ func TestScheduler_Stop(t *testing.T) {
 	})
 	t.Run("waits for jobs to finish processing before returning .Stop()", func(t *testing.T) {
 		t.Parallel()
-		// i := 0
+		i := 0
 		s := NewScheduler(time.UTC)
 		s.Every(1).Second().Do(func() {
 			time.Sleep(2 * time.Second)
-			// i = 1
+			i = 1
 		})
 		s.StartAsync()
 		time.Sleep(1 * time.Second) // enough time for job to run
 		s.Stop()
-		assert.Equal(t, 1, 1)
+		assert.Equal(t, 1, i)
 	})
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -635,7 +635,7 @@ func TestScheduler_Stop(t *testing.T) {
 		t.Parallel()
 		i := 0
 		s := NewScheduler(time.UTC)
-		s.Every(1).Second().Do(func() {
+		s.Every(10).Second().Do(func() {
 			time.Sleep(2 * time.Second)
 			i = 1
 		})


### PR DESCRIPTION
### What does this do?

Scheduler now waits for all running jobs to finish before returning. Fixes #237. 

### Which issue(s) does this PR fix/relate to?
Fixes #237 

### List any changes that modify/break current functionality
None.

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?
Yes.
- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
