### PR TITLE
add checkout step to formatting action

### DIFF
--- a/.github/workflows/file_formatting.yml
+++ b/.github/workflows/file_formatting.yml
@@ -12,6 +12,8 @@ jobs:
     name: check sorted
     runs-on: ubuntu-latest
     steps:
+      - name: checkout code
+        uses: actions/checkout@v2
       - name: verify example_test.go
         run: |
           grep "func " example_test.go | sort -C


### PR DESCRIPTION
### What does this do?
The `file_formatting.yml` file does not checkout the repository before
running, resulting in a file missing error. This PR adds the checkout
step.


### Which issue(s) does this PR fix/relate to?
See #231 


### List any changes that modify/break current functionality
None

### Have you included tests for your changes?
No

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
None