### PR TITLE
Append tags rather than overwriting

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -788,7 +788,7 @@ func (s *Scheduler) Tag(t ...string) *Scheduler {
 		}
 	}
 
-	job.tags = t
+	job.tags = append(job.tags, t...)
 	return s
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1220,6 +1220,20 @@ func TestScheduler_TagsUnique(t *testing.T) {
 
 }
 
+func TestScheduler_MultipleTagsChained(t *testing.T) {
+	const (
+		tag1 = "tag1"
+		tag2 = "tag2"
+	)
+
+	s := NewScheduler(time.UTC)
+
+	j, err := s.Every("1s").Tag(tag1).Tag(tag2).Do(func() {})
+	require.NoError(t, err)
+
+	assert.EqualValues(t, []string{tag1, tag2}, j.Tags())
+}
+
 func TestScheduler_DoParameterValidation(t *testing.T) {
 	testCases := []struct {
 		description string


### PR DESCRIPTION
### What does this do?
This PR changes `scheduler.Tag()` to append to, rather than overwrite, existing tags

### Which issue(s) does this PR fix/relate to?
I didn't create an issue because the README mentioned small changes can just send a PR. Here are some details I would have put in the issue:

#### Describe Bug
If multiple calls to `scheduler.Tag()` are chained together, only the last one called persists.

#### How To Reproduce
Check out [this Playground](https://play.golang.org/p/8ozf_TpCppd)

#### Expected Behavior
I expected multiple calls to `Tag()` to append to existing tags rather than overwrite.

### List any changes that modify/break current functionality
This shouldn't be a breaking change unless someone is using multiple calls to `Tag()` to conditionally overwrite previous ones.

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
No

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
While this was unexpected behavior to me, I understand it might be the intended way to use Tags, in which case this can be closed.
