### PR TITLE
Make FindJobsByTag exported

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -550,7 +550,7 @@ func (s *Scheduler) RunByTag(tag string) error {
 // RunByTagWithDelay is same as RunByTag but introduces a delay between
 // each job execution
 func (s *Scheduler) RunByTagWithDelay(tag string, d time.Duration) error {
-	jobs, err := s.findJobsByTag(tag)
+	jobs, err := s.FindJobsByTag(tag)
 	if err != nil {
 		return err
 	}
@@ -626,7 +626,7 @@ func (s *Scheduler) RemoveByTag(tag string) error {
 
 // RemoveByTags will remove Jobs that match all given tags.
 func (s *Scheduler) RemoveByTags(tags ...string) error {
-	jobs, err := s.findJobsByTag(tags...)
+	jobs, err := s.FindJobsByTag(tags...)
 	if err != nil {
 		return err
 	}
@@ -637,7 +637,8 @@ func (s *Scheduler) RemoveByTags(tags ...string) error {
 	return nil
 }
 
-func (s *Scheduler) findJobsByTag(tags ...string) ([]*Job, error) {
+// FindJobsByTag will return a slice of Jobs that match all given tags
+func (s *Scheduler) FindJobsByTag(tags ...string) ([]*Job, error) {
 	var jobs []*Job
 
 Jobs:


### PR DESCRIPTION
### What does this do?
This exports the `FindJobsByTag` function so that it can be used outside of the package. This is really useful for updating `Jobs` or displaying the `NextRun` time.

### Which issue(s) does this PR fix/relate to?
N/A

### List any changes that modify/break current functionality
None (unless this was un-exported for a reason).

### Have you included tests for your changes?
No because there is full coverage from this being used throughout the package. Let me know if I should add some specific tests.

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
