### PR TITLE
catch nils on job function creation failures

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -3,7 +3,6 @@ package gocron
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 
 	"golang.org/x/sync/semaphore"
 )
@@ -78,9 +77,9 @@ func (e *executor) start() {
 
 				switch f.runConfig.mode {
 				case defaultMode:
-					atomic.AddInt64(f.runState, 1)
+					f.incrementRunState()
 					callJobFuncWithParams(f.function, f.parameters)
-					atomic.AddInt64(f.runState, -1)
+					f.decrementRunState()
 				case singletonMode:
 					_, _, _ = f.limiter.Do("main", func() (interface{}, error) {
 						select {
@@ -90,9 +89,9 @@ func (e *executor) start() {
 							return nil, nil
 						default:
 						}
-						atomic.AddInt64(f.runState, 1)
+						f.incrementRunState()
 						callJobFuncWithParams(f.function, f.parameters)
-						atomic.AddInt64(f.runState, -1)
+						f.decrementRunState()
 						return nil, nil
 					})
 				}

--- a/job.go
+++ b/job.go
@@ -287,7 +287,9 @@ func (j *Job) stop() {
 	if j.timer != nil {
 		j.timer.Stop()
 	}
-	j.cancel()
+	if j.cancel != nil {
+		j.cancel()
+	}
 }
 
 // IsRunning reports whether any instances of the job function are currently running

--- a/job.go
+++ b/job.go
@@ -43,6 +43,18 @@ type jobFunction struct {
 	runState   *int64              // will be non-zero when jobs are running
 }
 
+func (jf *jobFunction) incrementRunState() {
+	if jf.runState != nil {
+		atomic.AddInt64(jf.runState, 1)
+	}
+}
+
+func (jf *jobFunction) decrementRunState() {
+	if jf.runState != nil {
+		atomic.AddInt64(jf.runState, -1)
+	}
+}
+
 type runConfig struct {
 	finiteRuns bool
 	maxRuns    int


### PR DESCRIPTION
### What does this do?
- job cancel can be nil
- job func state can be nil

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
closes #269 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
