### PR TITLE
handle error case better where every/cron is not called

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -37,7 +37,7 @@ var (
 
 func wrapOrError(toWrap error, err error) error {
 	var returnErr error
-	if toWrap != nil {
+	if toWrap != nil && !errors.Is(err, toWrap) {
 		returnErr = fmt.Errorf("%s: %w", err, toWrap)
 	} else {
 		returnErr = err

--- a/scheduler.go
+++ b/scheduler.go
@@ -739,6 +739,12 @@ func (s *Scheduler) Do(jobFun interface{}, params ...interface{}) (*Job, error) 
 		job.error = wrapOrError(job.error, ErrWeekdayNotSupported)
 	}
 
+	if job.unit != crontab && job.interval == 0 {
+		if job.unit != duration {
+			job.error = wrapOrError(job.error, ErrInvalidInterval)
+		}
+	}
+
 	if job.error != nil {
 		// delete the job from the scheduler as this job
 		// cannot be executed

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -889,6 +889,14 @@ func TestScheduler_Do(t *testing.T) {
 			},
 		},
 		{
+			description: "error due to every/cron not called",
+			evalFunc: func(s *Scheduler) {
+				_, err := s.Do(1)
+				assert.EqualError(t, err, ErrInvalidInterval.Error())
+				assert.Zero(t, s.Len(), "The job should be deleted if Every or Cron is not called")
+			},
+		},
+		{
 			description: "positive case",
 			evalFunc: func(s *Scheduler) {
 				_, err := s.Every(1).Day().Do(func() {})


### PR DESCRIPTION
### What does this do?
- in the wrapOrError function checks if the error already exists in the wrapping to avoid dupes
- within the Do() func, check that the interval isn't 0 and error if it is

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
