### PR TITLE
Add every first weekday of month (#274)

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -430,6 +430,12 @@ func ExampleScheduler_Month() {
 	_, _ = s.Month(1, 2).Every(1).Do(task)
 }
 
+func ExampleScheduler_MonthFirstWeekday() {
+	s := gocron.NewScheduler(time.UTC)
+	_, _ = s.MonthFirstWeekday(time.Monday).Do(task)
+	s.StartAsync()
+}
+
 func ExampleScheduler_MonthLastDay() {
 	s := gocron.NewScheduler(time.UTC)
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -696,6 +696,17 @@ Jobs:
 	return nil, ErrJobNotFoundWithTag
 }
 
+// MonthFirstWeekday sets the job to run the first specified weekday of the month
+func (s *Scheduler) MonthFirstWeekday(weekday time.Weekday) *Scheduler {
+	_, month, day := s.time.Now(time.UTC).Date()
+
+	if day < 7 {
+		return s.Cron(fmt.Sprintf("0 0 %d %d %d", day, month, weekday))
+	}
+
+	return s.Cron(fmt.Sprintf("0 0 %d %d %d", day, month+1, weekday))
+}
+
 // LimitRunsTo limits the number of executions of this job to n.
 // Upon reaching the limit, the job is removed from the scheduler.
 func (s *Scheduler) LimitRunsTo(i int) *Scheduler {


### PR DESCRIPTION
### What does this do?
It allows us to set the job to every first weekday of month

### Which issue(s) does this PR fix/relate to?
#274 

### Have you included tests for your changes?
Of course.

### Did you document any new/modified functionality?
Updated `example_test.go`