### PR TITLE
calling .Stop() from a separate goroutine now stops the blocking start

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -674,8 +674,20 @@ func ExampleScheduler_Stop() {
 	s.StartAsync()
 	s.Stop()
 	fmt.Println(s.IsRunning())
+
+	s = gocron.NewScheduler(time.UTC)
+
+	go func() {
+		time.Sleep(1 * time.Second)
+		s.Stop()
+	}()
+
+	s.StartBlocking()
+	fmt.Println(".Stop() stops the blocking start")
+
 	// Output:
 	// false
+	// .Stop() stops the blocking start
 }
 
 func ExampleScheduler_Sunday() {

--- a/executor.go
+++ b/executor.go
@@ -52,7 +52,7 @@ func (e *executor) start() {
 
 				if panicHandler != nil {
 					defer func() {
-						if r := recover(); r != nil {
+						if r := recover(); r != interface{}(nil) {
 							panicHandler(f.name, r)
 						}
 					}()

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -854,6 +854,20 @@ func TestScheduler_Stop(t *testing.T) {
 
 		assert.EqualValues(t, 1, atomic.LoadInt32(&i))
 	})
+	t.Run("stops a running scheduler calling .Stop()", func(t *testing.T) {
+		s := NewScheduler(time.UTC)
+
+		go func() {
+			time.Sleep(1 * time.Second)
+			assert.True(t, s.IsRunning())
+			s.Stop()
+			time.Sleep(100 * time.Millisecond) // wait for stop goroutine to catch up
+		}()
+
+		s.StartBlocking()
+		log.Println(".Stop() stops the blocking start")
+		assert.False(t, s.IsRunning())
+	})
 }
 
 func TestScheduler_StartAt(t *testing.T) {


### PR DESCRIPTION
### What does this do?


### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #346 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
