### PR TITLE
custom time provider for scheduler closes #353

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -26,7 +26,7 @@ type Scheduler struct {
 	runningMutex  sync.RWMutex
 	running       bool // represents if the scheduler is running at the moment or not
 
-	time     timeWrapper // wrapper around time.Time
+	time     TimeWrapper // wrapper around time.Time
 	executor *executor   // executes jobs passed via chan
 
 	tags sync.Map // for storing tags when unique tags is set
@@ -52,6 +52,20 @@ func NewScheduler(loc *time.Location) *Scheduler {
 		location:   loc,
 		running:    false,
 		time:       &trueTime{},
+		executor:   &executor,
+		tagsUnique: false,
+		stopChan:   make(chan struct{}, 1),
+	}
+}
+
+// NewSchedulerCustomTime creates a new Scheduler using a custom time provider overriding the system time
+func NewSchedulerCustomTime(loc *time.Location, tw TimeWrapper) *Scheduler {
+	executor := newExecutor()
+	return &Scheduler{
+		jobs:       make([]*Job, 0),
+		location:   loc,
+		running:    false,
+		time:       tw,
 		executor:   &executor,
 		tagsUnique: false,
 		stopChan:   make(chan struct{}, 1),

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ timeWrapper = (*fakeTime)(nil)
+var _ TimeWrapper = (*fakeTime)(nil)
 
 type fakeTime struct {
 	onNow func(location *time.Location) time.Time

--- a/timeHelper.go
+++ b/timeHelper.go
@@ -2,9 +2,9 @@ package gocron
 
 import "time"
 
-var _ timeWrapper = (*trueTime)(nil)
+var _ TimeWrapper = (*trueTime)(nil)
 
-type timeWrapper interface {
+type TimeWrapper interface {
 	Now(*time.Location) time.Time
 	Unix(int64, int64) time.Time
 	Sleep(time.Duration)


### PR DESCRIPTION
### What does this do?
Makes timeWrapper interface public (calling it TimeWrapper) and implements alternate Scheduler constructor NewSchedulerCustomTime receiving a TimeWrapper as an argument. 

### Which issue(s) does this PR fix/relate to?
<!--- Resolves #353 --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?


### Notes
