### PR TITLE
[BUG] Fix Data race when using RunByTag

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -45,6 +45,7 @@ var (
 	ErrInvalidInterval               = errors.New(".Every() interval must be greater than 0")
 	ErrInvalidIntervalType           = errors.New(".Every() interval must be int, time.Duration, or string")
 	ErrInvalidIntervalUnitsSelection = errors.New(".Every(time.Duration) and .Cron() cannot be used with units (e.g. .Seconds())")
+	ErrInvalidFunctionParameters     = errors.New("length of function parameters must match job function parameters")
 
 	ErrAtTimeNotSupported               = errors.New("the At() method is not supported for this time unit")
 	ErrWeekdayNotSupported              = errors.New("weekday is not supported for time unit")

--- a/job.go
+++ b/job.go
@@ -397,7 +397,6 @@ func (j *Job) SingletonMode() {
 	defer j.mu.Unlock()
 	j.runConfig.mode = singletonMode
 	j.jobFunction.limiter = &singleflight.Group{}
-
 }
 
 // shouldRun evaluates if this job should run again
@@ -410,10 +409,14 @@ func (j *Job) shouldRun() bool {
 
 // LastRun returns the time the job was run last
 func (j *Job) LastRun() time.Time {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
 	return j.lastRun
 }
 
 func (j *Job) setLastRun(t time.Time) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
 	j.lastRun = t
 }
 
@@ -432,7 +435,15 @@ func (j *Job) setNextRun(t time.Time) {
 
 // RunCount returns the number of time the job ran so far
 func (j *Job) RunCount() int {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
 	return j.runCount
+}
+
+func (j *Job) incrementRunCount() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.runCount++
 }
 
 func (j *Job) stop() {

--- a/scheduler.go
+++ b/scheduler.go
@@ -79,7 +79,7 @@ func (s *Scheduler) StartAsync() {
 	}
 }
 
-//start starts the scheduler, scheduling and running jobs
+// start starts the scheduler, scheduling and running jobs
 func (s *Scheduler) start() {
 	go s.executor.start()
 	s.setRunning(true)
@@ -342,7 +342,6 @@ func (s *Scheduler) calculateTotalDaysDifference(lastRun time.Time, daysToWeekda
 }
 
 func (s *Scheduler) calculateDays(job *Job, lastRun time.Time) nextRun {
-
 	if job.getInterval() == 1 {
 		lastRunDayPlusJobAtTime := s.roundToMidnight(lastRun).Add(job.getAtTime(lastRun))
 
@@ -533,6 +532,21 @@ func (s *Scheduler) run(job *Job) {
 		return
 	}
 
+	job = s.runJobWithDetails(job)
+	if job.error != nil {
+		// delete the job from the scheduler as this job
+		// cannot be executed
+		s.RemoveByReference(job)
+		return
+		// return job.error
+	}
+
+	s.executor.jobFunctions <- job.jobFunction.copy()
+	job.setLastRun(s.now())
+	job.incrementRunCount()
+}
+
+func (s *Scheduler) runJobWithDetails(job *Job) *Job {
 	job.mu.Lock()
 	defer job.mu.Unlock()
 
@@ -544,13 +558,11 @@ func (s *Scheduler) run(job *Job) {
 			job.parameters[job.parametersLen] = job.copy()
 		default:
 			// something is really wrong and we should never get here
-			return
+			job.error = wrapOrError(job.error, ErrInvalidFunctionParameters)
 		}
 	}
 
-	s.executor.jobFunctions <- job.jobFunction.copy()
-	job.setLastRun(s.now())
-	job.runCount++
+	return job
 }
 
 func (s *Scheduler) runContinuous(job *Job) {

--- a/scheduler.go
+++ b/scheduler.go
@@ -532,7 +532,7 @@ func (s *Scheduler) run(job *Job) {
 		return
 	}
 
-	job = s.runJobWithDetails(job)
+	job = s.addJobDetails(job)
 	if job.error != nil {
 		// delete the job from the scheduler as this job
 		// cannot be executed
@@ -546,7 +546,7 @@ func (s *Scheduler) run(job *Job) {
 	job.incrementRunCount()
 }
 
-func (s *Scheduler) runJobWithDetails(job *Job) *Job {
+func (s *Scheduler) addJobDetails(job *Job) *Job {
 	job.mu.Lock()
 	defer job.mu.Unlock()
 


### PR DESCRIPTION
### What does this do?
Resolves #350 Job lastRun was causing the data race when RunByTag. Wraps the `job.copy` in `Scheduler.run()` into separate method, `addJobDetails` and added locks on `job.runCount`, `job.lastRun`.

### Which issue(s) does this PR fix/relate to?
Resolves #350 
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?
Updated TestScheduler_RunByTag in `shceduler_test.go` to simulate multiple tasks being run by tag.

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
Added `ErrInvalidFunctionParameters     = errors.New("length of function parameters must match job function parameters")` But if this case will never be happening, update the `job.error`. Otherwise, it would be better to return the error.