### PR TITLE
Fix data race in lastRun

### DIFF
--- a/job.go
+++ b/job.go
@@ -160,7 +160,8 @@ func (j *Job) getInterval() int {
 }
 
 func (j *Job) neverRan() bool {
-	return j.lastRun.IsZero()
+	jobLastRun := j.LastRun()
+	return jobLastRun.IsZero()
 }
 
 func (j *Job) getStartsImmediately() bool {
@@ -415,8 +416,6 @@ func (j *Job) LastRun() time.Time {
 }
 
 func (j *Job) setLastRun(t time.Time) {
-	j.mu.Lock()
-	defer j.mu.Unlock()
 	j.lastRun = t
 }
 
@@ -435,15 +434,7 @@ func (j *Job) setNextRun(t time.Time) {
 
 // RunCount returns the number of time the job ran so far
 func (j *Job) RunCount() int {
-	j.mu.RLock()
-	defer j.mu.RUnlock()
 	return j.runCount
-}
-
-func (j *Job) incrementRunCount() {
-	j.mu.Lock()
-	defer j.mu.Unlock()
-	j.runCount++
 }
 
 func (j *Job) stop() {

--- a/scheduler.go
+++ b/scheduler.go
@@ -819,7 +819,8 @@ func (s *Scheduler) doCommon(jobFun interface{}, params ...interface{}) (*Job, e
 	job := s.getCurrentJob()
 
 	jobUnit := job.getUnit()
-	if shouldRunAtSpecificTime(job) && (jobUnit <= hours || jobUnit >= duration) {
+	jobLastRun := job.LastRun()
+	if job.getAtTime(jobLastRun) != 0 && (jobUnit <= hours || jobUnit >= duration) {
 		job.error = wrapOrError(job.error, ErrAtTimeNotSupported)
 	}
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -403,7 +403,8 @@ func (s *Scheduler) calculateDuration(job *Job) time.Duration {
 }
 
 func shouldRunAtSpecificTime(job *Job) bool {
-	return job.getAtTime(job.lastRun) != 0
+	jobLastRun := job.LastRun()
+	return job.getAtTime(jobLastRun) != 0
 }
 
 func (s *Scheduler) remainingDaysToWeekday(lastRun time.Time, job *Job) int {
@@ -532,21 +533,6 @@ func (s *Scheduler) run(job *Job) {
 		return
 	}
 
-	job = s.addJobDetails(job)
-	if job.error != nil {
-		// delete the job from the scheduler as this job
-		// cannot be executed
-		s.RemoveByReference(job)
-		return
-		// return job.error
-	}
-
-	s.executor.jobFunctions <- job.jobFunction.copy()
-	job.setLastRun(s.now())
-	job.incrementRunCount()
-}
-
-func (s *Scheduler) addJobDetails(job *Job) *Job {
 	job.mu.Lock()
 	defer job.mu.Unlock()
 
@@ -559,10 +545,13 @@ func (s *Scheduler) addJobDetails(job *Job) *Job {
 		default:
 			// something is really wrong and we should never get here
 			job.error = wrapOrError(job.error, ErrInvalidFunctionParameters)
+			return
 		}
 	}
 
-	return job
+	s.executor.jobFunctions <- job.jobFunction.copy()
+	job.setLastRun(s.now())
+	job.runCount++
 }
 
 func (s *Scheduler) runContinuous(job *Job) {
@@ -830,7 +819,7 @@ func (s *Scheduler) doCommon(jobFun interface{}, params ...interface{}) (*Job, e
 	job := s.getCurrentJob()
 
 	jobUnit := job.getUnit()
-	if job.getAtTime(job.lastRun) != 0 && (jobUnit <= hours || jobUnit >= duration) {
+	if shouldRunAtSpecificTime(job) && (jobUnit <= hours || jobUnit >= duration) {
 		job.error = wrapOrError(job.error, ErrAtTimeNotSupported)
 	}
 


### PR DESCRIPTION
### What does this do?
This fix covers the remaining data race issue in job lastRun. 

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Data race when using RunByTag

### List any changes that modify/break current functionality
Properly protect data race condition in `runContinuous`, `neverRan`, `shouldRunAtSpecificTime` - prevents potential dead lock issue previously introduced as well.

### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
