### PR TITLE
fix: use Scheduler.time.now() instead of time.Now()

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -569,7 +569,7 @@ func (s *Scheduler) runContinuous(job *Job) {
 	job.setTimer(time.AfterFunc(next.duration, func() {
 		if !next.dateTime.IsZero() {
 			for {
-				if time.Now().Unix() >= next.dateTime.Unix() {
+				if s.now().Unix() >= next.dateTime.Unix() {
 					break
 				}
 			}


### PR DESCRIPTION
### What does this do?

```go
// Use my custom global time
scheduler.CustomTime(&my.GlobalTime{})
```
The actual execution time of the task will vary.

should use:
```go
s.now().Unix() >= next.dateTime.Unix()
```
instead of:
```go
time.Now().Unix() >= next.dateTime.Unix()
```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
