### PR TITLE
Optimize job setTimer

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -569,7 +569,7 @@ func (s *Scheduler) runContinuous(job *Job) {
 	job.setTimer(time.AfterFunc(next.duration, func() {
 		if !next.dateTime.IsZero() {
 			for {
-				if time.Now().Unix() >= next.dateTime.Unix() {
+				if s.now().Unix() >= next.dateTime.Unix() {
 					break
 				}
 			}

--- a/scheduler.go
+++ b/scheduler.go
@@ -569,9 +569,11 @@ func (s *Scheduler) runContinuous(job *Job) {
 	job.setTimer(time.AfterFunc(next.duration, func() {
 		if !next.dateTime.IsZero() {
 			for {
-				if s.now().Unix() >= next.dateTime.Unix() {
+				n := s.now().UnixNano() - next.dateTime.UnixNano()
+				if n >= 0 {
 					break
 				}
+				s.time.Sleep(time.Duration(n))
 			}
 		}
 		s.runContinuous(job)


### PR DESCRIPTION
### What does this do?

One more optimization:

When NTP time is calibrated or a leap second occurs, the following conditions may occur:

Now: 2022-01-01T00:00:00Z
Job: 
    nextRun.duration = 2*time.Mintue, 
    nextRun.dateTime = 2022-01-01T00:02:00Z

//...

Now: 2022-01-01T00:02:00Z
// ntpdate
// system time is corrected
Now: 2022-01-01T00:01:58Z

```go
job.setTimer(time.AfterFunc(next.duration, func() {
	if !next.dateTime.IsZero() {
		for {
			if s.now().Unix() >= next.dateTime.Unix() {
				break
			}
			// ...will loop for 2 seconds
		}
	}
	s.runContinuous(job)
}))
```

This should be better:

```go
job.setTimer(time.AfterFunc(next.duration, func() {
	if !next.dateTime.IsZero() {
		for {
			n := s.now().UnixNano() - next.dateTime.UnixNano()
			if n >= 0 {
				break
			}
			s.time.Sleep(time.Duration(n))
		}
	}
	s.runContinuous(job)
}))
```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
