### PR TITLE
Stops all jobs when stopping scheduler (fix #367)

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -813,8 +813,15 @@ func (s *Scheduler) Stop() {
 
 func (s *Scheduler) stop() {
 	s.setRunning(false)
+	s.stopJobs(s.jobs)
 	s.executor.stop()
 	s.stopChan <- struct{}{}
+}
+
+func (s *Scheduler) stopJobs(jobs []*Job) {
+	for _, job := range jobs {
+		job.stop()
+	}
 }
 
 func (s *Scheduler) doCommon(jobFun interface{}, params ...interface{}) (*Job, error) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -834,6 +834,21 @@ func TestScheduler_Stop(t *testing.T) {
 		s.Stop()
 		assert.False(t, s.IsRunning())
 	})
+	t.Run("stops all jobs", func(t *testing.T) {
+		t.Parallel()
+		s := NewScheduler(time.UTC)
+		job, _ := s.Every(3).Second().Do(func() {
+			//noop
+		})
+		s.StartAsync()
+		time.Sleep(1 * time.Second) // enough time for job to run
+		preStopJobTimer := job.timer
+		s.Stop()
+		time.Sleep(3 * time.Second) // enough time for job timer to reset
+		afterStopJobTimer := job.timer
+
+		assert.Same(t, preStopJobTimer, afterStopJobTimer)
+	})
 	t.Run("waits for jobs to finish processing before returning .Stop()", func(t *testing.T) {
 		t.Parallel()
 		i := int32(0)


### PR DESCRIPTION
### What does this do?

This commit will call stop() on every job when the scheduler is stopped. This will prevent creating another job timer loop when the scheduler is started again.

### Which issue(s) does this PR fix/relate to?
Resolves #367  

### Have you included tests for your changes?
Yes
