### PR TITLE
Protect job.RunCount() with mutex

### DIFF
--- a/job.go
+++ b/job.go
@@ -434,6 +434,8 @@ func (j *Job) setNextRun(t time.Time) {
 
 // RunCount returns the number of time the job ran so far
 func (j *Job) RunCount() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
 	return j.runCount
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -323,14 +323,14 @@ func (s *Scheduler) calculateWeeks(job *Job, lastRun time.Time) nextRun {
 }
 
 func (s *Scheduler) calculateTotalDaysDifference(lastRun time.Time, daysToWeekday int, job *Job) int {
-	if job.getInterval() > 1 && job.RunCount() < len(job.Weekdays()) { // just count weeks after the first jobs were done
-		return daysToWeekday
-	}
-	if job.getInterval() > 1 && job.RunCount() >= len(job.Weekdays()) {
+	if job.getInterval() > 1 {
+		// just count weeks after the first jobs were done
+		if job.RunCount() < len(job.Weekdays()) {
+			return daysToWeekday
+		}
 		if daysToWeekday > 0 {
 			return int(job.getInterval())*7 - (allWeekDays - daysToWeekday)
 		}
-
 		return int(job.getInterval()) * 7
 	}
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1841,7 +1841,7 @@ func TestScheduler_WaitForSchedules(t *testing.T) {
 	require.NoError(t, err)
 	s.StartAsync()
 
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(1050 * time.Millisecond)
 	s.Stop()
 
 	counterMutex.RLock()


### PR DESCRIPTION
### What does this do?
Protect `job.RunCount()` with mutex and prevent the data race condition.

### Which issue(s) does this PR fix/relate to?
#374 


### List any changes that modify/break current functionality
`job.RunCount()` is being protected by mutex

### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
