### PR TITLE
solve issue where job intervals drift slightly

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -170,6 +170,8 @@ func (s *Scheduler) scheduleNextRun(job *Job) (bool, nextRun) {
 		return false, nextRun{}
 	}
 
+	lastRun := now
+
 	if job.neverRan() {
 		// Increment startAtTime to the future
 		if !job.startAtTime.IsZero() && job.startAtTime.Before(now) {
@@ -185,6 +187,8 @@ func (s *Scheduler) scheduleNextRun(job *Job) (bool, nextRun) {
 				job.startAtTime = job.startAtTime.Add(duration * count)
 			}
 		}
+	} else {
+		lastRun = job.LastRun()
 	}
 
 	if !job.shouldRun() {
@@ -192,10 +196,12 @@ func (s *Scheduler) scheduleNextRun(job *Job) (bool, nextRun) {
 		return false, nextRun{}
 	}
 
-	next := s.durationToNextRun(now, job)
+	next := s.durationToNextRun(lastRun, job)
 
+	job.setLastRun(job.NextRun())
 	if next.dateTime.IsZero() {
-		job.setNextRun(now.Add(next.duration))
+		next.dateTime = lastRun.Add(next.duration)
+		job.setNextRun(next.dateTime)
 	} else {
 		job.setNextRun(next.dateTime)
 	}
@@ -555,7 +561,6 @@ func (s *Scheduler) run(job *Job) {
 	}
 
 	s.executor.jobFunctions <- job.jobFunction.copy()
-	job.setLastRun(s.now())
 	job.runCount++
 }
 
@@ -571,7 +576,17 @@ func (s *Scheduler) runContinuous(job *Job) {
 		s.run(job)
 	}
 
-	job.setTimer(s.timer(next.duration, func() {
+	nextRun := next.dateTime.Sub(s.now())
+	if nextRun < 0 {
+		time.Sleep(nextRun.Abs())
+		shouldRun, next := s.scheduleNextRun(job)
+		if !shouldRun {
+			return
+		}
+		nextRun = next.dateTime.Sub(s.now())
+	}
+
+	job.setTimer(s.timer(nextRun, func() {
 		if !next.dateTime.IsZero() {
 			for {
 				n := s.now().UnixNano() - next.dateTime.UnixNano()

--- a/scheduler.go
+++ b/scheduler.go
@@ -578,7 +578,7 @@ func (s *Scheduler) runContinuous(job *Job) {
 
 	nextRun := next.dateTime.Sub(s.now())
 	if nextRun < 0 {
-		time.Sleep(nextRun.Abs())
+		time.Sleep(absDuration(nextRun))
 		shouldRun, next := s.scheduleNextRun(job)
 		if !shouldRun {
 			return


### PR DESCRIPTION
### What does this do?
sets the job next run calculation to go from the last run time instead of time now. then when setting the timer, subtract time now from the next run time to accommodate for the slight drift that may occur there. Also, set the last Run time to be the next run time before setting the new next run time. Then, because there are still cases where the next run comes back negative due to what appears to be some minor discrepancies in time and possibly due to the jobs running very fast, the negative duration abs is slept off and the next run is scheduled from there. 

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #319 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
