### PR TITLE
fix logic to wait for executor stop

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -26,12 +26,12 @@ func Test_ExecutorExecute(t *testing.T) {
 		runState:   &runState,
 	}
 
-	e.stop()
 	wg.Wait()
+	e.stop()
 }
 
 func Test_ExecutorPanicHandling(t *testing.T) {
-	panicHandled := make(chan bool)
+	panicHandled := make(chan bool, 1)
 
 	handler := func(jobName string, recoverData interface{}) {
 		fmt.Println("PanicHandler called:")
@@ -60,8 +60,8 @@ func Test_ExecutorPanicHandling(t *testing.T) {
 		runState:   &runState,
 	}
 
-	e.stop()
 	wg.Wait()
+	e.stop()
 
 	state := <-panicHandled
 	assert.Equal(t, state, true)


### PR DESCRIPTION
### What does this do?
Add `stoppedCh` aside from `stopCh`, which is used to wait for the executor to stop

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves #391.

### List any changes that modify/break current functionality


### Have you included tests for your changes?
No

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
