### PR TITLE
Fix flaky SetEventListeners test

### DIFF
--- a/job_test.go
+++ b/job_test.go
@@ -247,8 +247,8 @@ func TestJob_SetEventListeners(t *testing.T) {
 		})
 
 		s.StartAsync()
-		s.stop()
 		wg.Wait()
+		s.Stop()
 
 		require.NoError(t, err)
 		assert.True(t, jobRanPassed)


### PR DESCRIPTION
Stop should be called after the job has been scheduled.

The failure can be reproduced by

```
go test -p 4 -count=50 -v -run TestJob_SetEventListeners
```