### PR TITLE
Attempt to fix flaky testAt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.19
 require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.8.1
+	go.uber.org/goleak v1.2.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
@@ -12,10 +16,14 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+go.uber.org/goleak v1.2.0 h1:xqgm/S+aQvhWFTtR0XK3Jvg7z8kGV8P4X14IzwN3Eqk=
+go.uber.org/goleak v1.2.0/go.mod h1:XJYK+MuIchqpmGmUSAzotztawfKvYLUIgg7guXrwVUo=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -253,12 +253,11 @@ func TestAt(t *testing.T) {
 
 		select {
 		case <-time.After(1 * time.Second):
-			s.stop()
 			log.Println(now.Add(time.Minute))
 			log.Println(dayJob.nextRun)
 			assert.Equal(t, now.Add(1*time.Minute), dayJob.nextRun)
-		case <-semaphore:
 			s.stop()
+		case <-semaphore:
 			t.Fatal("job ran even though scheduled in future")
 		}
 	})


### PR DESCRIPTION
### What does this do?

This PR attempts to fix flaky test.

Suspect there is a resource leak (scheduler) on each test iteration in https://github.com/go-co-op/gocron/blob/main/scheduler_test.go#L231 so it will run continuous and eventually will trigger this line: https://github.com/go-co-op/gocron/blob/main/scheduler.go#L597

I tried to run using [goleak](https://github.com/uber-go/goleak) test and it is proven there is a leak.

So, calling stop on each assertion in that test case will free the resource.

```
=== RUN   TestAt/job_scheduled_for_future_hasn't_run_yet
2023/02/13 14:25:22 1970-01-01 12:01:00 +0000 UTC
2023/02/13 14:25:22 1970-01-01 12:01:00 +0000 UTC
    scheduler_test.go:262: found unexpected goroutines:
        [Goroutine 8 in state select, with github.com/go-co-op/gocron.(*executor).start on top of the stack:
        goroutine 8 [select]:
        github.com/go-co-op/gocron.(*executor).start(0xc000077860)
                C:/Users/kenny.karnama/go/src/github.com/go-co-op/gocron/executor.go:48 +0xe5
        created by github.com/go-co-op/gocron.(*Scheduler).start
                C:/Users/kenny.karnama/go/src/github.com/go-co-op/gocron/scheduler.go:89 +0x6a
        ]
```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->

https://github.com/go-co-op/gocron/issues/414

### List any changes that modify/break current functionality

Call `s.Stop` on each assertion

### Have you included tests for your changes?

- Added verifyLeak
- Run `go test -v -count=1000 -run '^TestAt$'` and there is no panic

### Did you document any new/modified functionality?

-

### Notes

-