### PR TITLE
Fix panic in getCurrentJob()

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -1174,11 +1174,17 @@ func (s *Scheduler) Sunday() *Scheduler {
 }
 
 func (s *Scheduler) getCurrentJob() *Job {
+
 	if len(s.Jobs()) == 0 {
 		s.setJobs([]*Job{s.newJob(0)})
 		s.jobCreated = true
 	}
-	return s.Jobs()[len(s.Jobs())-1]
+
+	s.jobsMutex.RLock()
+	defer s.jobsMutex.RUnlock()
+
+	return s.jobs[len(s.jobs)-1]
+
 }
 
 func (s *Scheduler) now() time.Time {


### PR DESCRIPTION
### What does this do?
getCurrentJob() made two calls to Jobs() and used the length of the second one to get the latest job. Jobs() uses a mutex but since it's called twice the length can change between these calls which occasionally leads to a race condition and panic. This is more if jobs are removed often.

This PR directly access jobs list in getCurrentJob and uses a single lock instead of two separate ones.

### Which issue(s) does this PR fix/relate to?
Resolves a panic.

### List any changes that modify/break current functionality
None.

### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
