### PR TITLE
job: Pad `ScheduledAtTime(s)` with leading zeroes

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -95,7 +95,7 @@ func ExampleJob_ScheduledAtTime() {
 	fmt.Println(job1.ScheduledAtTime())
 	// Output:
 	// 10:30
-	// 8:0
+	// 08:00
 }
 
 func ExampleJob_ScheduledAtTimes() {
@@ -104,7 +104,7 @@ func ExampleJob_ScheduledAtTimes() {
 	s.StartAsync()
 	fmt.Println(job.ScheduledAtTimes())
 	// Output:
-	// [8:0 10:30]
+	// [08:00 10:30]
 }
 
 func ExampleJob_ScheduledTime() {
@@ -657,7 +657,6 @@ func ExampleScheduler_Seconds() {
 	_, _ = s.Every(1).Seconds().Do(task)
 	_, _ = s.Every("1s").Seconds().Do(task)
 	_, _ = s.Every(time.Second).Seconds().Do(task)
-
 }
 
 func ExampleScheduler_SetMaxConcurrentJobs() {

--- a/job.go
+++ b/job.go
@@ -336,17 +336,17 @@ func (j *Job) ScheduledTime() time.Time {
 // If multiple times are set, the earliest time will be returned.
 func (j *Job) ScheduledAtTime() string {
 	if len(j.atTimes) == 0 {
-		return "0:0"
+		return "00:00"
 	}
 
-	return fmt.Sprintf("%d:%d", j.getFirstAtTime()/time.Hour, (j.getFirstAtTime()%time.Hour)/time.Minute)
+	return fmt.Sprintf("%02d:%02d", j.getFirstAtTime()/time.Hour, (j.getFirstAtTime()%time.Hour)/time.Minute)
 }
 
 // ScheduledAtTimes returns the specific times of day the Job will run at
 func (j *Job) ScheduledAtTimes() []string {
 	r := make([]string, len(j.atTimes))
 	for i, t := range j.atTimes {
-		r[i] = fmt.Sprintf("%d:%d", t/time.Hour, (t%time.Hour)/time.Minute)
+		r[i] = fmt.Sprintf("%02d:%02d", t/time.Hour, (t%time.Hour)/time.Minute)
 	}
 
 	return r


### PR DESCRIPTION
I found it a bit odd that times were printed as `8:3` instead of `08:03` when using these methods, so pad them with leading zeroes for clarity.