### PR TITLE
Fix a bug with scheduling next runs on daylight savings change days

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-co-op/gocron
+module github.com/gomaps/gocron
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gomaps/gocron
+module github.com/go-co-op/gocron
 
 go 1.19
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -400,11 +400,6 @@ func (s *Scheduler) calculateDuration(job *Job) time.Duration {
 	}
 }
 
-func shouldRunAtSpecificTime(job *Job) bool {
-	jobLastRun := job.LastRun()
-	return job.getAtTime(jobLastRun) != 0
-}
-
 func (s *Scheduler) remainingDaysToWeekday(lastRun time.Time, job *Job) int {
 	weekDays := job.Weekdays()
 	sort.Slice(weekDays, func(i, j int) bool {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -405,19 +405,19 @@ func TestDaylightSavingsScheduled(t *testing.T) {
 		return dt.In(loc)
 	}
 
-	before_to_edt := fakeTime{onNow: func(l *time.Location) time.Time {
+	beforeToEDT := fakeTime{onNow: func(l *time.Location) time.Time {
 		return time.Date(2023, 3, 12, 1, 50, 50, 0, loc)
 	}}
-	to_edt := fakeTime{onNow: func(l *time.Location) time.Time {
+	toEDT := fakeTime{onNow: func(l *time.Location) time.Time {
 		return time.Date(2023, 3, 12, 5, 0, 0, 0, loc)
 	}}
-	before_to_est := fakeTime{onNow: func(l *time.Location) time.Time {
+	beforeToEST := fakeTime{onNow: func(l *time.Location) time.Time {
 		return time.Date(2022, 11, 6, 1, 50, 50, 0, loc)
 	}}
-	after_to_est := fakeTime{onNow: func(l *time.Location) time.Time {
+	afterToEST := fakeTime{onNow: func(l *time.Location) time.Time {
 		return fromRFC3339("2022-11-06T09:00:01.000Z")
 	}}
-	to_est := fakeTime{onNow: func(l *time.Location) time.Time {
+	toEST := fakeTime{onNow: func(l *time.Location) time.Time {
 		return time.Date(2022, 11, 6, 4, 0, 0, 0, loc)
 	}}
 
@@ -427,21 +427,21 @@ func TestDaylightSavingsScheduled(t *testing.T) {
 		jobCreateFn     func(s *Scheduler) *Scheduler
 		expectedNextRun time.Time
 	}{
-		{"EST no change", before_to_edt, func(s *Scheduler) *Scheduler { return s.Every(1).Day().At("01:59") }, time.Date(2023, 3, 12, 1, 59, 0, 0, loc)},
-		{"EST->EDT every day", to_edt, func(s *Scheduler) *Scheduler { return s.Every(1).Day().At("20:00") }, time.Date(2023, 3, 12, 20, 0, 0, 0, loc)},
-		{"EST->EDT every 2 week", to_edt, func(s *Scheduler) *Scheduler { return s.Every(2).Week().At("17:00") }, time.Date(2023, 3, 26, 17, 0, 0, 0, loc)},
-		{"EST->EDT every 2 Tuesday", to_edt, func(s *Scheduler) *Scheduler { return s.Every(2).Tuesday().At("16:00") }, time.Date(2023, 3, 14, 16, 0, 0, 0, loc)},
-		{"EST->EDT every Sunday", to_edt, func(s *Scheduler) *Scheduler { return s.Every(1).Sunday().At("04:30") }, time.Date(2023, 3, 19, 4, 30, 0, 0, loc)},
-		{"EST->EDT every month", to_edt, func(s *Scheduler) *Scheduler { return s.Every(3).Month(12).At("14:00") }, time.Date(2023, 6, 12, 14, 0, 0, 0, loc)},
-		{"EST->EDT every last day of month", to_edt, func(s *Scheduler) *Scheduler { return s.Every(1).MonthLastDay().At("13:00") }, time.Date(2023, 3, 31, 13, 0, 0, 0, loc)},
+		{"EST no change", beforeToEDT, func(s *Scheduler) *Scheduler { return s.Every(1).Day().At("01:59") }, time.Date(2023, 3, 12, 1, 59, 0, 0, loc)},
+		{"EST->EDT every day", toEDT, func(s *Scheduler) *Scheduler { return s.Every(1).Day().At("20:00") }, time.Date(2023, 3, 12, 20, 0, 0, 0, loc)},
+		{"EST->EDT every 2 week", toEDT, func(s *Scheduler) *Scheduler { return s.Every(2).Week().At("17:00") }, time.Date(2023, 3, 26, 17, 0, 0, 0, loc)},
+		{"EST->EDT every 2 Tuesday", toEDT, func(s *Scheduler) *Scheduler { return s.Every(2).Tuesday().At("16:00") }, time.Date(2023, 3, 14, 16, 0, 0, 0, loc)},
+		{"EST->EDT every Sunday", toEDT, func(s *Scheduler) *Scheduler { return s.Every(1).Sunday().At("04:30") }, time.Date(2023, 3, 19, 4, 30, 0, 0, loc)},
+		{"EST->EDT every month", toEDT, func(s *Scheduler) *Scheduler { return s.Every(3).Month(12).At("14:00") }, time.Date(2023, 6, 12, 14, 0, 0, 0, loc)},
+		{"EST->EDT every last day of month", toEDT, func(s *Scheduler) *Scheduler { return s.Every(1).MonthLastDay().At("13:00") }, time.Date(2023, 3, 31, 13, 0, 0, 0, loc)},
 
-		{"EDT no change", before_to_est, func(s *Scheduler) *Scheduler { return s.Every(1).Day().At("01:59") }, time.Date(2022, 11, 6, 1, 59, 0, 0, loc)},
-		{"EDT->EST every day", to_est, func(s *Scheduler) *Scheduler { return s.Every(1).Day().At("20:00") }, time.Date(2022, 11, 6, 20, 0, 0, 0, loc)},
-		{"EDT->EST every 2 week", to_est, func(s *Scheduler) *Scheduler { return s.Every(2).Week().At("18:00") }, time.Date(2022, 11, 20, 18, 0, 0, 0, loc)},
-		{"EDT->EST every 2 Tuesday", to_est, func(s *Scheduler) *Scheduler { return s.Every(2).Tuesday().At("15:00") }, time.Date(2022, 11, 8, 15, 0, 0, 0, loc)},
-		{"EDT->EST every Sunday", after_to_est, func(s *Scheduler) *Scheduler { return s.Every(1).Sunday().At("01:30") }, time.Date(2022, 11, 13, 1, 30, 0, 0, loc)},
-		{"EDT->EST every month", to_est, func(s *Scheduler) *Scheduler { return s.Every(3).Month(6).At("14:30") }, time.Date(2023, 2, 6, 14, 30, 0, 0, loc)},
-		{"EDT->EST every last day of month", to_est, func(s *Scheduler) *Scheduler { return s.Every(1).MonthLastDay().At("13:15") }, time.Date(2022, 11, 30, 13, 15, 0, 0, loc)},
+		{"EDT no change", beforeToEST, func(s *Scheduler) *Scheduler { return s.Every(1).Day().At("01:59") }, time.Date(2022, 11, 6, 1, 59, 0, 0, loc)},
+		{"EDT->EST every day", toEST, func(s *Scheduler) *Scheduler { return s.Every(1).Day().At("20:00") }, time.Date(2022, 11, 6, 20, 0, 0, 0, loc)},
+		{"EDT->EST every 2 week", toEST, func(s *Scheduler) *Scheduler { return s.Every(2).Week().At("18:00") }, time.Date(2022, 11, 20, 18, 0, 0, 0, loc)},
+		{"EDT->EST every 2 Tuesday", toEST, func(s *Scheduler) *Scheduler { return s.Every(2).Tuesday().At("15:00") }, time.Date(2022, 11, 8, 15, 0, 0, 0, loc)},
+		{"EDT->EST every Sunday", afterToEST, func(s *Scheduler) *Scheduler { return s.Every(1).Sunday().At("01:30") }, time.Date(2022, 11, 13, 1, 30, 0, 0, loc)},
+		{"EDT->EST every month", toEST, func(s *Scheduler) *Scheduler { return s.Every(3).Month(6).At("14:30") }, time.Date(2023, 2, 6, 14, 30, 0, 0, loc)},
+		{"EDT->EST every last day of month", toEST, func(s *Scheduler) *Scheduler { return s.Every(1).MonthLastDay().At("13:15") }, time.Date(2022, 11, 30, 13, 15, 0, 0, loc)},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What does this do?
This fixes a bug in how gocron schedules scheduled next day, week/weekday, month tasks. Previously, the next run was calculated by rounding the current date to midnight, adding the scheduled time ("at time" represented as a duration), and then adding the necessary day, week, or month interval. This methodology fails on daylight savings transition days. 

For example, suppose gocron was run on March 12, 2023 (first day of daylight savings time) and needs to set up a task that runs at 8pm every night. The initial calculation of the next run date time will calculate the next run by rounding the current time to midnight (March 12, 2023 at 00:00) and adding the scheduled time ("at time" of 20:00 represented as 20 hours in duration). Normally, this yields 8pm but since daylight savings time started earlier at 3am, the actual result is 9pm. Thus, the scheduled tasks will run 1 hour late until either a power cycle of gocron at 12:00am or after the next run on March 13, 2023.

This PR fixes the issue by removing the addition operation and instead, populate a new `time.Time` object with the last run's date and the deconstructed hours, minutes, seconds from the "at time" duration.

### Which issue(s) does this PR fix/relate to?
N/A

### List any changes that modify/break current functionality
I don't think this breaks current functionality.

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?
No

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
It's possible I missed a few locations but I think I covered most of it. Please let me know if I missed any scenarios.