### PR TITLE
add func for getting all tags

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -351,6 +351,15 @@ func ExampleScheduler_Friday() {
 	// Friday
 }
 
+func ExampleScheduler_GetAllTags() {
+	s := gocron.NewScheduler(time.UTC)
+	_, _ = s.Every(1).Second().Tag("tag1").Do(task)
+	_, _ = s.Every(1).Second().Tag("tag2").Do(task)
+	fmt.Println(s.GetAllTags())
+	// Output:
+	// [tag1 tag2]
+}
+
 func ExampleScheduler_Hour() {
 	s := gocron.NewScheduler(time.UTC)
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -966,6 +966,22 @@ func (s *Scheduler) Tag(t ...string) *Scheduler {
 	return s
 }
 
+// GetAllTags returns all tags.
+func (s *Scheduler) GetAllTags() []string {
+	var tags []string
+	if s.tagsUnique {
+		s.tags.Range(func(key, value interface{}) bool {
+			tags = append(tags, key.(string))
+			return true
+		})
+	} else {
+		for _, job := range s.jobs {
+			tags = append(tags, job.tags...)
+		}
+	}
+	return tags
+}
+
 // StartAt schedules the next run of the Job. If this time is in the past, the configured interval will be used
 // to calculate the next future time
 func (s *Scheduler) StartAt(t time.Time) *Scheduler {

--- a/scheduler.go
+++ b/scheduler.go
@@ -975,15 +975,8 @@ func (s *Scheduler) Tag(t ...string) *Scheduler {
 // GetAllTags returns all tags.
 func (s *Scheduler) GetAllTags() []string {
 	var tags []string
-	if s.tagsUnique {
-		s.tags.Range(func(key, value interface{}) bool {
-			tags = append(tags, key.(string))
-			return true
-		})
-	} else {
-		for _, job := range s.jobs {
-			tags = append(tags, job.tags...)
-		}
+	for _, job := range s.Jobs() {
+		tags = append(tags, job.Tags()...)
 	}
 	return tags
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2,7 +2,6 @@ package gocron
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -909,7 +908,7 @@ func TestScheduler_Stop(t *testing.T) {
 		t.Parallel()
 		s := NewScheduler(time.UTC)
 		job, _ := s.Every(3).Second().Do(func() {
-			//noop
+			// noop
 		})
 		s.StartAsync()
 		time.Sleep(1 * time.Second) // enough time for job to run
@@ -1038,7 +1037,7 @@ func TestScheduler_CalculateNextRun(t *testing.T) {
 		{name: "job runs every 2 days, just ran at 5:30AM and should be scheduled for 2 days at 8:30AM", job: &Job{mu: &jobMutex{}, interval: 2, unit: days, atTimes: []time.Duration{8*time.Hour + 30*time.Minute}, lastRun: januaryFirst2020At(5, 30, 0)}, wantTimeUntilNextRun: (2 * day) + 3*time.Hour},
 		{name: "job runs every 2 days, just ran at 8:30AM and should be scheduled for 2 days at 8:30AM", job: &Job{mu: &jobMutex{}, interval: 2, unit: days, atTimes: []time.Duration{8*time.Hour + 30*time.Minute}, lastRun: januaryFirst2020At(8, 30, 0)}, wantTimeUntilNextRun: 2 * day},
 		{name: "daily, last run was 1 second ago", job: &Job{mu: &jobMutex{}, interval: 1, unit: days, atTimes: []time.Duration{12 * time.Hour}, lastRun: ft.Now(time.UTC).Add(-time.Second)}, wantTimeUntilNextRun: 1 * time.Second},
-		//// WEEKS
+		// // WEEKS
 		{name: "every week should run in 7 days", job: &Job{mu: &jobMutex{}, interval: 1, unit: weeks, lastRun: januaryFirst2020At(0, 0, 0)}, wantTimeUntilNextRun: 7 * day},
 		{name: "every week with .At time rule should run respect .At time rule", job: &Job{mu: &jobMutex{}, interval: 1, atTimes: []time.Duration{_getHours(9) + _getMinutes(30)}, unit: weeks, lastRun: januaryFirst2020At(9, 30, 0)}, wantTimeUntilNextRun: 7 * day},
 		{name: "every two weeks at 09:30AM should run in 14 days at 09:30AM", job: &Job{mu: &jobMutex{}, interval: 2, unit: weeks, lastRun: januaryFirst2020At(0, 0, 0)}, wantTimeUntilNextRun: 14 * day},
@@ -1070,7 +1069,7 @@ func TestScheduler_CalculateNextRun(t *testing.T) {
 		{name: "every last day of the month started on december 31 should run on january 31 of the next year", job: &Job{mu: &jobMutex{}, interval: 1, unit: months, daysOfTheMonth: []int{-1}, lastRun: januaryFirst2019At(0, 0, 0).AddDate(0, 0, -1)}, wantTimeUntilNextRun: 31 * day},
 		{name: "every last day of 2 months started on december 31, 2018 should run on february 28, 2019", job: &Job{mu: &jobMutex{}, interval: 2, unit: months, daysOfTheMonth: []int{-1}, lastRun: januaryFirst2019At(0, 0, 0).AddDate(0, 0, -1)}, wantTimeUntilNextRun: 31*day + 28*day},
 		{name: "every last day of 2 months started on december 31, 2019 should run on february 29, 2020", job: &Job{mu: &jobMutex{}, interval: 2, unit: months, daysOfTheMonth: []int{-1}, lastRun: januaryFirst2020At(0, 0, 0).AddDate(0, 0, -1)}, wantTimeUntilNextRun: 31*day + 29*day},
-		//// WEEKDAYS
+		// // WEEKDAYS
 		{name: "every weekday starting on one day before it should run this weekday", job: &Job{mu: &jobMutex{}, interval: 1, unit: weeks, scheduledWeekdays: []time.Weekday{*_tuesdayWeekday()}, lastRun: mondayAt(0, 0, 0)}, wantTimeUntilNextRun: 1 * day},
 		{name: "every weekday starting on same weekday should run in 7 days", job: &Job{mu: &jobMutex{}, interval: 1, unit: weeks, scheduledWeekdays: []time.Weekday{*_tuesdayWeekday()}, lastRun: mondayAt(0, 0, 0).AddDate(0, 0, 1)}, wantTimeUntilNextRun: 7 * day},
 		{name: "every 2 weekdays counting this week's weekday should run next weekday", job: &Job{mu: &jobMutex{}, interval: 2, unit: weeks, scheduledWeekdays: []time.Weekday{*_tuesdayWeekday()}, lastRun: mondayAt(0, 0, 0)}, wantTimeUntilNextRun: day},

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -908,7 +908,7 @@ func TestScheduler_Stop(t *testing.T) {
 		t.Parallel()
 		s := NewScheduler(time.UTC)
 		job, _ := s.Every(3).Second().Do(func() {
-			// noop
+			//noop
 		})
 		s.StartAsync()
 		time.Sleep(1 * time.Second) // enough time for job to run
@@ -1037,7 +1037,7 @@ func TestScheduler_CalculateNextRun(t *testing.T) {
 		{name: "job runs every 2 days, just ran at 5:30AM and should be scheduled for 2 days at 8:30AM", job: &Job{mu: &jobMutex{}, interval: 2, unit: days, atTimes: []time.Duration{8*time.Hour + 30*time.Minute}, lastRun: januaryFirst2020At(5, 30, 0)}, wantTimeUntilNextRun: (2 * day) + 3*time.Hour},
 		{name: "job runs every 2 days, just ran at 8:30AM and should be scheduled for 2 days at 8:30AM", job: &Job{mu: &jobMutex{}, interval: 2, unit: days, atTimes: []time.Duration{8*time.Hour + 30*time.Minute}, lastRun: januaryFirst2020At(8, 30, 0)}, wantTimeUntilNextRun: 2 * day},
 		{name: "daily, last run was 1 second ago", job: &Job{mu: &jobMutex{}, interval: 1, unit: days, atTimes: []time.Duration{12 * time.Hour}, lastRun: ft.Now(time.UTC).Add(-time.Second)}, wantTimeUntilNextRun: 1 * time.Second},
-		// // WEEKS
+		//// WEEKS
 		{name: "every week should run in 7 days", job: &Job{mu: &jobMutex{}, interval: 1, unit: weeks, lastRun: januaryFirst2020At(0, 0, 0)}, wantTimeUntilNextRun: 7 * day},
 		{name: "every week with .At time rule should run respect .At time rule", job: &Job{mu: &jobMutex{}, interval: 1, atTimes: []time.Duration{_getHours(9) + _getMinutes(30)}, unit: weeks, lastRun: januaryFirst2020At(9, 30, 0)}, wantTimeUntilNextRun: 7 * day},
 		{name: "every two weeks at 09:30AM should run in 14 days at 09:30AM", job: &Job{mu: &jobMutex{}, interval: 2, unit: weeks, lastRun: januaryFirst2020At(0, 0, 0)}, wantTimeUntilNextRun: 14 * day},
@@ -1069,7 +1069,7 @@ func TestScheduler_CalculateNextRun(t *testing.T) {
 		{name: "every last day of the month started on december 31 should run on january 31 of the next year", job: &Job{mu: &jobMutex{}, interval: 1, unit: months, daysOfTheMonth: []int{-1}, lastRun: januaryFirst2019At(0, 0, 0).AddDate(0, 0, -1)}, wantTimeUntilNextRun: 31 * day},
 		{name: "every last day of 2 months started on december 31, 2018 should run on february 28, 2019", job: &Job{mu: &jobMutex{}, interval: 2, unit: months, daysOfTheMonth: []int{-1}, lastRun: januaryFirst2019At(0, 0, 0).AddDate(0, 0, -1)}, wantTimeUntilNextRun: 31*day + 28*day},
 		{name: "every last day of 2 months started on december 31, 2019 should run on february 29, 2020", job: &Job{mu: &jobMutex{}, interval: 2, unit: months, daysOfTheMonth: []int{-1}, lastRun: januaryFirst2020At(0, 0, 0).AddDate(0, 0, -1)}, wantTimeUntilNextRun: 31*day + 29*day},
-		// // WEEKDAYS
+		//// WEEKDAYS
 		{name: "every weekday starting on one day before it should run this weekday", job: &Job{mu: &jobMutex{}, interval: 1, unit: weeks, scheduledWeekdays: []time.Weekday{*_tuesdayWeekday()}, lastRun: mondayAt(0, 0, 0)}, wantTimeUntilNextRun: 1 * day},
 		{name: "every weekday starting on same weekday should run in 7 days", job: &Job{mu: &jobMutex{}, interval: 1, unit: weeks, scheduledWeekdays: []time.Weekday{*_tuesdayWeekday()}, lastRun: mondayAt(0, 0, 0).AddDate(0, 0, 1)}, wantTimeUntilNextRun: 7 * day},
 		{name: "every 2 weekdays counting this week's weekday should run next weekday", job: &Job{mu: &jobMutex{}, interval: 2, unit: weeks, scheduledWeekdays: []time.Weekday{*_tuesdayWeekday()}, lastRun: mondayAt(0, 0, 0)}, wantTimeUntilNextRun: day},

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3,6 +3,7 @@ package gocron
 import (
 	"fmt"
 	"log"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -2299,5 +2300,68 @@ func TestScheduler_DoWithJobDetails(t *testing.T) {
 		require.NoError(t, err)
 		s.StartAsync()
 		time.Sleep(500 * time.Millisecond)
+	})
+}
+
+func TestScheduler_GetAllTags(t *testing.T) {
+	t.Run("tags unique", func(t *testing.T) {
+		testCases := []struct {
+			description string
+			tags        []string
+			expected    []string
+		}{
+			{"no tags", []string{}, nil},
+			{"one tag", []string{"tag1"}, []string{"tag1"}},
+			{"two tags", []string{"tag1", "tag2"}, []string{"tag1", "tag2"}},
+			{"two tags with duplicates", []string{"tag1", "tag2", "tag1"}, []string{"tag1", "tag2"}},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				s := NewScheduler(time.UTC)
+				s.TagsUnique()
+
+				for _, tag := range tc.tags {
+					_, err := s.Tag(tag).Every("100ms").Do(func() {})
+					require.NoError(t, err)
+				}
+
+				tags := s.GetAllTags()
+				sort.Strings(tc.expected)
+				sort.Strings(tags)
+
+				assert.Equal(t, tc.expected, tags)
+			})
+		}
+	})
+
+	t.Run("tags not unique", func(t *testing.T) {
+		testCases := []struct {
+			description string
+			tags        []string
+			expected    []string
+		}{
+			{"no tags", []string{}, nil},
+			{"one tag", []string{"tag1"}, []string{"tag1"}},
+			{"two tags", []string{"tag1", "tag2"}, []string{"tag1", "tag2"}},
+			{"two tags with duplicates", []string{"tag1", "tag2", "tag1"}, []string{"tag1", "tag2", "tag1"}},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.description, func(t *testing.T) {
+				s := NewScheduler(time.UTC)
+
+				for _, tag := range tc.tags {
+					_, err := s.Tag(tag).Every("100ms").Do(func() {})
+					require.NoError(t, err)
+				}
+
+				tags := s.GetAllTags()
+				sort.Strings(tc.expected)
+				sort.Strings(tags)
+
+				assert.Equal(t, tc.expected, tags)
+			})
+		}
 	})
 }


### PR DESCRIPTION
### What does this do?

This PR adds a function for getting all tags.

#### Use Case

Imagine you have a database table of thousands of SQL queries you need to run according to their configured crontab schedules, and you have a service that fetches these configs and uses gocron to schedule each query to execute. This service also polls the database on a schedule to sync the configured query configs with corresponding jobs in the gocron scheduler. It would be nice to have some sort of `GetAllTags()` function so that if you needed to delete jobs that no longer need to run, you can compare the list of all tags to the list of all newly fetched query configs.

```golang
scheduler := gocron.NewScheduler(time.UTC)
scheduler.TagsUnique()

// map of active queries to schedule
queryConfigs := map[string]string{
  "query1": "select * from user",
  "query2": "select * from company",
}

// remove all jobs that no longer need to run
for _, tag := range scheduler.GetAllTags() {
  if _, ok := queryConfigs[tag]; !ok {
    scheduler.RemoveByTag(tag)
  }
}
```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->

N/A

### List any changes that modify/break current functionality

None

### Have you included tests for your changes?

Yes

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [x] Updated `README.md` (marking this as done but didn't change anything)

### Notes

