### PR TITLE
fix issue where Weekday(), StartAt() and At() set at the same time result in unexpected run times

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -217,7 +217,7 @@ func (s *Scheduler) scheduleNextRun(job *Job) (bool, nextRun) {
 // durationToNextRun calculate how much time to the next run, depending on unit
 func (s *Scheduler) durationToNextRun(lastRun time.Time, job *Job) nextRun {
 	// job can be scheduled with .StartAt()
-	if job.getStartAtTime().After(lastRun) {
+	if job.getFirstAtTime() == 0 && job.getStartAtTime().After(lastRun) {
 		return nextRun{duration: job.getStartAtTime().Sub(s.now()), dateTime: job.getStartAtTime()}
 	}
 
@@ -232,6 +232,9 @@ func (s *Scheduler) durationToNextRun(lastRun time.Time, job *Job) nextRun {
 			next = s.calculateWeekday(job, lastRun)
 		} else {
 			next = s.calculateWeeks(job, lastRun)
+		}
+		if next.dateTime.Before(job.getStartAtTime()) {
+			return s.durationToNextRun(job.getStartAtTime(), job)
 		}
 	case months:
 		next = s.calculateMonths(job, lastRun)


### PR DESCRIPTION
### What does this do?
in our nextrun calculation, only run using the startat time if At() isn't set. This bug only surfaced if you were using weekday (possibly other places, but I couldn't find others) and would cause a job to run before the actual first At time should be. In this case, `StartAt()` really behaves as a "startAfter". The At() time will be scheduled at the first instance after the `StartAt()` time.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #399 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
