### PR TITLE
fix singleton mode to avoid goroutine leaks, and accurate run counts

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -439,6 +439,7 @@ func ExampleScheduler_LimitRunsTo() {
 	j, _ := s.Every(1).Second().LimitRunsTo(1).Do(task)
 	s.StartAsync()
 
+	time.Sleep(time.Millisecond * 100)
 	fmt.Println(j.RunCount())
 	// Output:
 	// 1

--- a/executor.go
+++ b/executor.go
@@ -40,6 +40,29 @@ func newExecutor() executor {
 	}
 }
 
+func runJob(f jobFunction) {
+	f.runCount.Add(1)
+	f.isRunning.Store(true)
+	callJobFunc(f.eventListeners.onBeforeJobExecution)
+	callJobFuncWithParams(f.function, f.parameters)
+	callJobFunc(f.eventListeners.onAfterJobExecution)
+	f.isRunning.Store(false)
+}
+
+func (jf *jobFunction) singletonRunner() {
+	for {
+		select {
+		case <-jf.ctx.Done():
+			return
+		default:
+			if jf.singletonQueue.Load() != 0 {
+				runJob(*jf)
+				jf.singletonQueue.Add(-1)
+			}
+		}
+	}
+}
+
 func (e *executor) start() {
 	stopCtx, cancel := context.WithCancel(context.Background())
 	runningJobsWg := sync.WaitGroup{}
@@ -79,7 +102,6 @@ func (e *executor) start() {
 
 							if err := e.maxRunningJobs.Acquire(f.ctx, 1); err != nil {
 								break
-
 							}
 						}
 					}
@@ -87,29 +109,11 @@ func (e *executor) start() {
 					defer e.maxRunningJobs.Release(1)
 				}
 
-				runJob := func() {
-					f.incrementRunState()
-					callJobFunc(f.eventListeners.onBeforeJobExecution)
-					callJobFuncWithParams(f.function, f.parameters)
-					callJobFunc(f.eventListeners.onAfterJobExecution)
-					f.decrementRunState()
-				}
-
 				switch f.runConfig.mode {
 				case defaultMode:
-					runJob()
+					runJob(f)
 				case singletonMode:
-					_, _, _ = f.limiter.Do("main", func() (any, error) {
-						select {
-						case <-stopCtx.Done():
-							return nil, nil
-						case <-f.ctx.Done():
-							return nil, nil
-						default:
-						}
-						runJob()
-						return nil, nil
-					})
+					f.singletonQueue.Add(1)
 				}
 			}()
 		case <-e.stopCh:

--- a/scheduler.go
+++ b/scheduler.go
@@ -588,7 +588,6 @@ func (s *Scheduler) run(job *Job) {
 	}
 
 	s.executor.jobFunctions <- job.jobFunction.copy()
-	job.runCount++
 }
 
 func (s *Scheduler) runContinuous(job *Job) {
@@ -1264,6 +1263,10 @@ func (s *Scheduler) Update() (*Job, error) {
 
 	if job.runWithDetails {
 		return s.DoWithJobDetails(job.function, job.parameters...)
+	}
+
+	if job.runConfig.mode == singletonMode {
+		job.SingletonMode()
 	}
 
 	return s.Do(job.function, job.parameters...)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1185,6 +1185,7 @@ func TestScheduler_CalculateNextRun(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewScheduler(time.UTC)
 			s.time = ft
+			tc.job.runCount = &atomic.Int64{}
 			got := s.durationToNextRun(tc.job.LastRun(), tc.job).duration
 			assert.Equalf(t, tc.wantTimeUntilNextRun, got, fmt.Sprintf("expected %s / got %s", tc.wantTimeUntilNextRun.String(), got.String()))
 		})
@@ -2255,7 +2256,7 @@ func TestScheduler_CheckEveryWeekHigherThanOne(t *testing.T) {
 						assert.Equal(t, wantTimeUntilNextRunTwoWeeksLessOneDay, got)
 					}
 				}
-				job.runCount++
+				job.runCount.Add(1)
 			}
 		})
 	}


### PR DESCRIPTION
### What does this do?

1. replaces the limiter.singleflight with the `singletonRunner()` func that is spun up in a goroutine per singleton job. The singelton runner handles checking the `singletonQueue` to see if requests to run have been made for that specific job func
1. changes the jobState to be a atomic.Bool and named `isRunning` to more accurately reflect what it's tracking
1. moves runCount onto the jobFunction to allow incrementing to occur in the executor using an atomic.Int64 - makes it accurate in cases where the job execution is limited

note in the results in this example that the number of goroutines does not exceed 4/5 goroutines which are:
- scheduler
- executor
- executor task for job1 (sometimes we catch it in the print, hence 4 or 5)
- executor task for job2
- and the singletonRunner

when job1 is removed we see only the 3 expected goroutines
- scheduler
- executor
- executor task for job2

```go
package main

import (
	"fmt"
	"runtime"
	"time"

	"github.com/go-co-op/gocron"
)

func main() {
	s := gocron.NewScheduler(time.UTC)

	// job 1 - long running
	job, _ := s.Every("100ms").Tag("job1").SingletonMode().Do(func() {
		time.Sleep(1 * time.Second)
	})
	//job 2 - monitors goroutine count and job 1 run count
	s.Every("500ms").Tag("job2").Do(func() {
		fmt.Printf("goroutine count: %d |||||| job 1's run count: %d\n", runtime.NumGoroutine(), job.RunCount())
	})
	s.StartAsync()

	time.Sleep(5 * time.Second)
	s.RemoveByReference(job)
	time.Sleep(6 * time.Second)
}
```

Results:

```
goroutine count: 5 |||||| job 1's run count: 0
goroutine count: 5 |||||| job 1's run count: 1
goroutine count: 5 |||||| job 1's run count: 2
goroutine count: 4 |||||| job 1's run count: 2
goroutine count: 4 |||||| job 1's run count: 3
goroutine count: 4 |||||| job 1's run count: 3
goroutine count: 4 |||||| job 1's run count: 4
goroutine count: 4 |||||| job 1's run count: 4
goroutine count: 4 |||||| job 1's run count: 4
goroutine count: 4 |||||| job 1's run count: 5
goroutine count: 4 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
goroutine count: 3 |||||| job 1's run count: 5
```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #442 
resolves #404 
resolves #439 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes

