### PR TITLE
rework the exectuor stopping to use context with cancel and wait groups instead of stop chans

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -1,6 +1,7 @@
 package gocron
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -10,6 +11,10 @@ import (
 
 func Test_ExecutorExecute(t *testing.T) {
 	e := newExecutor()
+	stopCtx, cancel := context.WithCancel(context.Background())
+	e.ctx = stopCtx
+	e.cancel = cancel
+	e.jobsWg = &sync.WaitGroup{}
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
@@ -41,6 +46,10 @@ func Test_ExecutorPanicHandling(t *testing.T) {
 	SetPanicHandler(handler)
 
 	e := newExecutor()
+	stopCtx, cancel := context.WithCancel(context.Background())
+	e.ctx = stopCtx
+	e.cancel = cancel
+	e.jobsWg = &sync.WaitGroup{}
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)


### PR DESCRIPTION
### What does this do?
rather than using two channels to send a `stop` and then respond with a `stopped` communication, this uses a context with cancellation and wait groups to handle stopping and then waiting for the goroutines to complete. 

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #425 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
