### PR TITLE
refactor the max concurrent jobs executor func

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,29 @@
 [![CI State](https://github.com/go-co-op/gocron/actions/workflows/go_test.yml/badge.svg?branch=main&event=push)](https://github.com/go-co-op/gocron/actions)
 ![Go Report Card](https://goreportcard.com/badge/github.com/go-co-op/gocron) [![Go Doc](https://godoc.org/github.com/go-co-op/gocron?status.svg)](https://pkg.go.dev/github.com/go-co-op/gocron)
 
-gocron is a job scheduling package which lets you run Go functions at pre-determined intervals using a simple, human-friendly syntax.
+gocron is a job scheduling package which lets you run Go functions at pre-determined intervals 
+using a simple, human-friendly syntax.
 
-gocron is a Golang scheduler implementation similar to the Ruby module [clockwork](https://github.com/tomykaira/clockwork) and the Python job scheduling package [schedule](https://github.com/dbader/schedule).
+gocron is a Golang scheduler implementation similar to the Ruby module 
+[clockwork](https://github.com/tomykaira/clockwork) and the Python job scheduling package [schedule](https://github.com/dbader/schedule).
 
 See also these two great articles that were used for design input:
 
 - [Rethinking Cron](http://adam.herokuapp.com/past/2010/4/13/rethinking_cron/)
 - [Replace Cron with Clockwork](http://adam.herokuapp.com/past/2010/6/30/replace_cron_with_clockwork/)
 
-If you want to chat, you can find us at Slack! [<img src="https://img.shields.io/badge/gophers-gocron-brightgreen?logo=slack">](https://gophers.slack.com/archives/CQ7T0T1FW)
+If you want to chat, you can find us at Slack! 
+[<img src="https://img.shields.io/badge/gophers-gocron-brightgreen?logo=slack">](https://gophers.slack.com/archives/CQ7T0T1FW)
 
 ## Concepts
 
-- **Scheduler**: The scheduler tracks all the jobs assigned to it and makes sure they are passed to the executor when ready to be run. The scheduler is able to manage overall aspects of job behavior like limiting how many jobs are running at one time.
-- **Job**: The job is simply aware of the task (go function) it's provided and is therefore only able to perform actions related to that task like preventing itself from overruning a previous task that is taking a long time.
-- **Executor**: The executor, as it's name suggests, is simply responsible for calling the task (go function) that the job hands to it when sent by the scheduler.
+- **Scheduler**: The scheduler tracks all the jobs assigned to it and makes sure they are passed to the executor when
+  ready to be run. The scheduler is able to manage overall aspects of job behavior like limiting how many jobs 
+  are running at one time.
+- **Job**: The job is simply aware of the task (go function) it's provided and is therefore only able to perform
+  actions related to that task like preventing itself from overruning a previous task that is taking a long time.
+- **Executor**: The executor, as it's name suggests, is simply responsible for calling the task (go function) that
+  the job hands to it when sent by the scheduler.
 
 ## Examples
 

--- a/executor.go
+++ b/executor.go
@@ -102,8 +102,8 @@ func (e *executor) limitModeRunner() {
 				default:
 					e.jobsWg.Add(1)
 					go func() {
-						defer e.jobsWg.Done()
 						runJob(jf)
+						e.jobsWg.Done()
 						e.limitModeRunningJobs.Store(e.limitModeRunningJobs.Load() - 1)
 					}()
 				}

--- a/executor_test.go
+++ b/executor_test.go
@@ -1,7 +1,6 @@
 package gocron
 
 import (
-	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -11,14 +10,10 @@ import (
 
 func Test_ExecutorExecute(t *testing.T) {
 	e := newExecutor()
-	stopCtx, cancel := context.WithCancel(context.Background())
-	e.ctx = stopCtx
-	e.cancel = cancel
-	e.jobsWg = &sync.WaitGroup{}
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	go e.start()
+	e.start()
 
 	e.jobFunctions <- jobFunction{
 		name: "test_fn",
@@ -46,14 +41,10 @@ func Test_ExecutorPanicHandling(t *testing.T) {
 	SetPanicHandler(handler)
 
 	e := newExecutor()
-	stopCtx, cancel := context.WithCancel(context.Background())
-	e.ctx = stopCtx
-	e.cancel = cancel
-	e.jobsWg = &sync.WaitGroup{}
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	go e.start()
+	e.start()
 
 	e.jobFunctions <- jobFunction{
 		name: "test_fn",

--- a/job.go
+++ b/job.go
@@ -451,6 +451,7 @@ func (j *Job) stop() {
 	}
 	if j.cancel != nil {
 		j.cancel()
+		j.ctx, j.cancel = context.WithCancel(context.Background())
 	}
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -92,12 +92,7 @@ func (s *Scheduler) StartAsync() {
 
 // start starts the scheduler, scheduling and running jobs
 func (s *Scheduler) start() {
-	stopCtx, cancel := context.WithCancel(context.Background())
-	s.executor.ctx = stopCtx
-	s.executor.cancel = cancel
-	s.executor.jobsWg = &sync.WaitGroup{}
-
-	go s.executor.start()
+	s.executor.start()
 	s.setRunning(true)
 	s.runJobs(s.Jobs())
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1595,7 +1595,7 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 		// 200ms - jobs 1 & 3 run
 		// 300ms - jobs 2 & 3 run, job 1 hits the limit and waits
 		{
-			"wait mode", 2, WaitMode, 8, false,
+			"wait mode", 2, WaitMode, 7, false,
 			func() {
 				semaphore <- true
 				time.Sleep(100 * time.Millisecond)
@@ -1604,7 +1604,7 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 
 		//// Same as above - this confirms the same behavior when jobs are removed rather than the scheduler being stopped
 		{
-			"wait mode - with job removal", 2, WaitMode, 8, true,
+			"wait mode - with job removal", 2, WaitMode, 7, true,
 			func() {
 				semaphore <- true
 				time.Sleep(100 * time.Millisecond)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1651,7 +1651,6 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 				s.RemoveByReference(j1)
 				s.RemoveByReference(j2)
 				s.RemoveByReference(j3)
-				defer s.Stop()
 			} else {
 				s.Stop()
 			}
@@ -1670,6 +1669,10 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 
 			assert.GreaterOrEqual(t, counter, tc.expectedRuns-1)
 			assert.LessOrEqual(t, counter, tc.expectedRuns+1)
+
+			if tc.removeJobs {
+				s.Stop()
+			}
 		})
 	}
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1667,8 +1667,8 @@ func TestScheduler_SetMaxConcurrentJobs(t *testing.T) {
 				}
 			}
 
-			assert.GreaterOrEqual(t, counter, tc.expectedRuns-1)
-			assert.LessOrEqual(t, counter, tc.expectedRuns+1)
+			assert.GreaterOrEqual(t, counter, tc.expectedRuns-2)
+			assert.LessOrEqual(t, counter, tc.expectedRuns+2)
 
 			if tc.removeJobs {
 				s.Stop()


### PR DESCRIPTION
### What does this do?
the existing limit mode was leaking goroutines due to the implementation spinning up a goroutine for each job whether or not it is blocked. So if there a lot of jobs being queued the goroutines will pile up.

this implementation uses a single goroutine limited job runner that reads jobs from a mutex protected slice and runs then when slots are available within the max concurrent runs limit.

Also, some minor test clean up / refactoring

Example:

```go
package main

import (
	"log"
	"runtime"
	"time"

	"github.com/go-co-op/gocron"
)

func main() {
	s := gocron.NewScheduler(time.UTC)
	s.SetMaxConcurrentJobs(1, gocron.WaitMode)

	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
	s.Every("1s").Do(func() {
		log.Printf("job 1 start. grc: %d\n", runtime.NumGoroutine())
		time.Sleep(2 * time.Second)
		log.Printf("job 1 end. grc: %d\n", runtime.NumGoroutine())
	})
	s.Every("1s").Do(func() {
		log.Printf("job 2 start. grc: %d\n", runtime.NumGoroutine())
		time.Sleep(3 * time.Second)
		log.Printf("job 2 end. grc: %d\n", runtime.NumGoroutine())
	})

	s.StartAsync()

	time.Sleep(6 * time.Second)
	log.Println("stopping")
	s.Stop()
	log.Println("stopped")
	time.Sleep(4 * time.Second)

	log.Println("starting")
	s.StartAsync()
	log.Println("started")

	time.Sleep(4 * time.Second)
	log.Println("stopping")
	s.Stop()
	log.Println("stopped")
	time.Sleep(4 * time.Second)
	log.Printf("grc: %d\n", runtime.NumGoroutine())
}
```

Output

```
2023/04/18 10:46:25.910403 job 2 start. grc: 4
2023/04/18 10:46:28.911593 job 2 end. grc: 5
2023/04/18 10:46:28.911663 job 1 start. grc: 4
2023/04/18 10:46:30.912345 job 1 end. grc: 6
2023/04/18 10:46:30.912398 job 2 start. grc: 4
2023/04/18 10:46:31.910430 stopping
2023/04/18 10:46:33.913496 job 2 end. grc: 3
2023/04/18 10:46:33.913552 stopped
2023/04/18 10:46:37.914718 starting
2023/04/18 10:46:37.914816 started
2023/04/18 10:46:37.914896 job 1 start. grc: 7
2023/04/18 10:46:39.915239 job 1 end. grc: 4
2023/04/18 10:46:39.915290 job 2 start. grc: 4
2023/04/18 10:46:41.915176 stopping
2023/04/18 10:46:42.915705 job 2 end. grc: 3
2023/04/18 10:46:42.915733 stopped
2023/04/18 10:46:46.916830 grc: 1
```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
