### PR TITLE
fix: deadlock for blocking channel

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -1377,7 +1377,7 @@ func (s *Scheduler) CustomTimer(customTimer func(d time.Duration, f func()) *tim
 func (s *Scheduler) StopBlockingChan() {
 	s.startBlockingStopChanMutex.Lock()
 	if s.startBlockingStopChan != nil {
-		s.startBlockingStopChan <- struct{}{}
+		close(s.startBlockingStopChan)
 	}
 	s.startBlockingStopChanMutex.Unlock()
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -82,7 +82,12 @@ func (s *Scheduler) StartBlocking() {
 	s.startBlockingStopChanMutex.Lock()
 	s.startBlockingStopChan = make(chan struct{}, 1)
 	s.startBlockingStopChanMutex.Unlock()
+
 	<-s.startBlockingStopChan
+
+	s.startBlockingStopChanMutex.Lock()
+	s.startBlockingStopChan = nil
+	s.startBlockingStopChanMutex.Unlock()
 }
 
 // StartAsync starts all jobs without blocking the current thread

--- a/scheduler.go
+++ b/scheduler.go
@@ -868,10 +868,10 @@ func (s *Scheduler) Stop() {
 }
 
 func (s *Scheduler) stop() {
-	s.setRunning(false)
 	s.stopJobs(s.jobs)
 	s.executor.stop()
 	s.StopBlockingChan()
+	s.setRunning(false)
 }
 
 func (s *Scheduler) stopJobs(jobs []*Job) {
@@ -1376,8 +1376,9 @@ func (s *Scheduler) CustomTimer(customTimer func(d time.Duration, f func()) *tim
 
 func (s *Scheduler) StopBlockingChan() {
 	s.startBlockingStopChanMutex.Lock()
-	if s.startBlockingStopChan != nil {
+	if s.IsRunning() && s.startBlockingStopChan != nil {
 		close(s.startBlockingStopChan)
+		s.startBlockingStopChan = nil
 	}
 	s.startBlockingStopChanMutex.Unlock()
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -1378,7 +1378,6 @@ func (s *Scheduler) StopBlockingChan() {
 	s.startBlockingStopChanMutex.Lock()
 	if s.IsRunning() && s.startBlockingStopChan != nil {
 		close(s.startBlockingStopChan)
-		s.startBlockingStopChan = nil
 	}
 	s.startBlockingStopChanMutex.Unlock()
 }


### PR DESCRIPTION
### What does this do?

This is a scenario that occurs with a very small probability. The `StartBlocking()` and `Stop()` methods are executed almost concurrently. When the stop is notified through the channel, the start has not been monitored, so a deadlock problem occurs.

When will the stop method and start be executed concurrently, such as closing gocron after receiving a linux signal.

![image](https://user-images.githubusercontent.com/3785409/236624840-46d4e1a1-fd59-481f-87c7-c0b313e76e4c.png)


### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
