### PR TITLE
Fix data race in executor with enabling the limit mode

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -96,7 +96,6 @@ func (jf *jobFunction) singletonRunner() {
 }
 
 func (e *executor) limitModeRunner() {
-	e.limitModeFuncWg.Add(1)
 	for {
 		select {
 		case <-e.ctx.Done():
@@ -169,6 +168,7 @@ func (e *executor) run() {
 				if countRunning < int64(e.limitModeMaxRunningJobs) {
 					diff := int64(e.limitModeMaxRunningJobs) - countRunning
 					for i := int64(0); i < diff; i++ {
+						e.limitModeFuncWg.Add(1)
 						go e.limitModeRunner()
 						e.limitModeFuncsRunning.Add(1)
 					}


### PR DESCRIPTION

### What does this do?

The root cause is we write the limitModeFuncsRunning(a wait group) in the new goroutine, so the Go data race detector will think they have the data race due to reading and writing in different routines.

I'm sorry for didn't run tests in data race mode in the previous PR. @JohnRoesler 


### Which issue(s) does this PR fix/relate to?

Fix the data race in https://github.com/go-co-op/gocron/actions/runs/4905158223/jobs/8758756592

### List any changes that modify/break current functionality
None

### Have you included tests for your changes?

None

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
