### PR TITLE
fix: executor run block when executor.stop()

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -194,10 +194,16 @@ func (e *executor) run() {
 					switch e.limitMode {
 					case RescheduleMode:
 						if e.limitModeRunningJobs.Load() < int64(e.limitModeMaxRunningJobs) {
-							e.limitModeQueue <- f
+							select {
+							case e.limitModeQueue <- f:
+							case <-e.ctx.Done():
+							}
 						}
 					case WaitMode:
-						e.limitModeQueue <- f
+						select {
+						case e.limitModeQueue <- f:
+						case <-e.ctx.Done():
+						}
 					}
 					return
 				}


### PR DESCRIPTION
### What does this do?

When we close gocron, the `limitModeRunner` goroutine exits after receive ctx.Done().  Because there is no method to listen `limitModeQueue`, will pushing data to the `limitModeQueue` be blocked ？

`this is my guess`

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
