### PR TITLE
fix: make panic on startblocking with no jobs more clear

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -762,15 +762,14 @@ func ExampleScheduler_StartImmediately() {
 
 func ExampleScheduler_Stop() {
 	s := gocron.NewScheduler(time.UTC)
-	_, _ = s.Every(1).Second().Do(task)
 	s.StartAsync()
 	s.Stop()
 	fmt.Println(s.IsRunning())
 
 	s = gocron.NewScheduler(time.UTC)
-
+	_, _ = s.Every(1).Second().Do(task)
 	go func() {
-		time.Sleep(1 * time.Second)
+		time.Sleep(2 * time.Second)
 		s.Stop()
 	}()
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -88,7 +88,7 @@ func (s *Scheduler) StartBlocking() {
 		time.Sleep(time.Second)
 		if len(s.Jobs()) == 0 {
 			// panic here because if we don't, a panic will result due to a deadlock
-			// as the all goroutines will be asleep as no jobs are being published
+			// as all the goroutines will be asleep as no jobs are being published
 			// to the executor from the scheduler. This way, the panic message will
 			// be clearer to the end user.
 			panic("StartBlocking cannot be called with zero jobs in the Scheduler")

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2690,7 +2690,6 @@ func TestScheduler_WithDistributedLocker_With_Name(t *testing.T) {
 }
 
 func TestScheduler_StartBlocking(t *testing.T) {
-
 	t.Run("start blocking without jobs panics", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2688,3 +2688,12 @@ func TestScheduler_WithDistributedLocker_With_Name(t *testing.T) {
 		})
 	}
 }
+
+func TestScheduler_StartBlocking(t *testing.T) {
+
+	t.Run("start blocking without jobs panics", func(t *testing.T) {
+		s := NewScheduler(time.UTC)
+
+		assert.Panics(t, s.StartBlocking)
+	})
+}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -995,6 +995,7 @@ func TestScheduler_Stop(t *testing.T) {
 	})
 	t.Run("stops a running scheduler calling .Stop()", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
+		s.Every("1s").Do(func() {})
 
 		go func() {
 			time.Sleep(time.Second)


### PR DESCRIPTION
### What does this do?
as the comment in the code notes: 

```
// panic here because if we don't, a panic will result due to a deadlock
// as all the goroutines will be asleep as no jobs are being published
// to the executor from the scheduler. This way, the panic message will
// be clearer to the end user.
```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
