### PR TITLE
move support back for go 1.16

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -946,7 +946,7 @@ func ExampleScheduler_WithDistributedLocker() {
 // ---------------------------------------------------------------------
 
 func ExampleSetPanicHandler() {
-	gocron.SetPanicHandler(func(jobName string, _ any) {
+	gocron.SetPanicHandler(func(jobName string, _ interface{}) {
 		fmt.Printf("Panic in job: %s", jobName)
 		fmt.Println("do something to handle the panic")
 	})

--- a/executor_test.go
+++ b/executor_test.go
@@ -2,10 +2,10 @@ package gocron
 
 import (
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/atomic"
 )
 
 func Test_ExecutorExecute(t *testing.T) {
@@ -21,10 +21,10 @@ func Test_ExecutorExecute(t *testing.T) {
 			assert.Equal(t, arg, "test")
 			wg.Done()
 		},
-		parameters:     []any{"test"},
-		isRunning:      &atomic.Bool{},
-		runStartCount:  &atomic.Int64{},
-		runFinishCount: &atomic.Int64{},
+		parameters:     []interface{}{"test"},
+		isRunning:      atomic.NewBool(false),
+		runStartCount:  atomic.NewInt64(0),
+		runFinishCount: atomic.NewInt64(0),
 	}
 
 	wg.Wait()
@@ -34,7 +34,7 @@ func Test_ExecutorExecute(t *testing.T) {
 func Test_ExecutorPanicHandling(t *testing.T) {
 	panicHandled := make(chan bool, 1)
 
-	handler := func(jobName string, recoverData any) {
+	handler := func(jobName string, recoverData interface{}) {
 		panicHandled <- true
 	}
 
@@ -54,9 +54,9 @@ func Test_ExecutorPanicHandling(t *testing.T) {
 			a[0] = "This will panic"
 		},
 		parameters:     nil,
-		isRunning:      &atomic.Bool{},
-		runStartCount:  &atomic.Int64{},
-		runFinishCount: &atomic.Int64{},
+		isRunning:      atomic.NewBool(false),
+		runStartCount:  atomic.NewInt64(0),
+		runFinishCount: atomic.NewInt64(0),
 	}
 
 	wg.Wait()

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,15 @@
 module github.com/go-co-op/gocron
 
-go 1.20
+go 1.16
 
 require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.8.2
+	go.uber.org/atomic v1.9.0
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -21,10 +21,13 @@ github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/gocron.go
+++ b/gocron.go
@@ -17,7 +17,7 @@ import (
 
 // PanicHandlerFunc represents a type that can be set to handle panics occurring
 // during job execution.
-type PanicHandlerFunc func(jobName string, recoverData any)
+type PanicHandlerFunc func(jobName string, recoverData interface{})
 
 // The global panic handler
 var (
@@ -88,13 +88,13 @@ const (
 	crontab
 )
 
-func callJobFunc(jobFunc any) {
+func callJobFunc(jobFunc interface{}) {
 	if jobFunc != nil {
 		reflect.ValueOf(jobFunc).Call([]reflect.Value{})
 	}
 }
 
-func callJobFuncWithParams(jobFunc any, params []any) {
+func callJobFuncWithParams(jobFunc interface{}, params []interface{}) {
 	f := reflect.ValueOf(jobFunc)
 	if len(params) != f.Type().NumIn() {
 		return
@@ -106,7 +106,7 @@ func callJobFuncWithParams(jobFunc any, params []any) {
 	f.Call(in)
 }
 
-func getFunctionName(fn any) string {
+func getFunctionName(fn interface{}) string {
 	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 }
 

--- a/gocron_test.go
+++ b/gocron_test.go
@@ -109,8 +109,8 @@ func TestParseTime(t *testing.T) {
 
 func Test_callJobFuncWithParams(t *testing.T) {
 	type args struct {
-		jobFunc any
-		params  []any
+		jobFunc interface{}
+		params  []interface{}
 	}
 	tests := []struct {
 		name string
@@ -128,14 +128,14 @@ func Test_callJobFuncWithParams(t *testing.T) {
 			name: "test call func with single arg",
 			args: args{
 				jobFunc: func(arg string) {},
-				params:  []any{"test"},
+				params:  []interface{}{"test"},
 			},
 		},
 		{
 			name: "test call func with wrong arg type",
 			args: args{
 				jobFunc: func(arg int) {},
-				params:  []any{"test"},
+				params:  []interface{}{"test"},
 			},
 			err: true,
 		},
@@ -143,7 +143,7 @@ func Test_callJobFuncWithParams(t *testing.T) {
 			name: "test call func with wrong arg count",
 			args: args{
 				jobFunc: func(arg int) {},
-				params:  []any{},
+				params:  []interface{}{},
 			},
 			err: true,
 		},
@@ -173,7 +173,7 @@ func panicFnToErr(fn func()) (err error) {
 
 func Test_getFunctionName(t *testing.T) {
 	type args struct {
-		fn any
+		fn interface{}
 	}
 	tests := []struct {
 		name string

--- a/job_test.go
+++ b/job_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 func TestTags(t *testing.T) {
@@ -183,7 +183,7 @@ func TestJob_shouldRunAgain(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runCount := &atomic.Int64{}
+			runCount := atomic.NewInt64(0)
 			runCount.Store(int64(tt.runCount))
 			j := &Job{
 				mu: &jobMutex{},

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
 
 var _ TimeWrapper = (*fakeTime)(nil)
@@ -60,7 +60,7 @@ func TestImmediateExecution(t *testing.T) {
 func TestScheduler_Every_InvalidInterval(t *testing.T) {
 	testCases := []struct {
 		description   string
-		interval      any
+		interval      interface{}
 		expectedError string
 	}{
 		{"zero", 0, ErrInvalidInterval.Error()},
@@ -336,27 +336,27 @@ func TestMultipleAtTimesDecoding(t *testing.T) {
 	exp := []time.Duration{_getHours(1), _getHours(3), _getHours(4), _getHours(7), _getHours(15)}
 	testCases := []struct {
 		name   string
-		params []any
+		params []interface{}
 		result []time.Duration
 	}{
 		{
 			name:   "multiple simple strings",
-			params: []any{"03:00", "15:00", "01:00", "07:00", "04:00"},
+			params: []interface{}{"03:00", "15:00", "01:00", "07:00", "04:00"},
 			result: exp,
 		},
 		{
 			name:   "single string separated by semicolons",
-			params: []any{"03:00;15:00;01:00;07:00;04:00"},
+			params: []interface{}{"03:00;15:00;01:00;07:00;04:00"},
 			result: exp,
 		},
 		{
 			name:   "interpolation of semicolons string, time.Time and simple string",
-			params: []any{"03:00;15:00;01:00", time.Date(0, 0, 0, 7, 0, 0, 0, time.UTC), "04:00"},
+			params: []interface{}{"03:00;15:00;01:00", time.Date(0, 0, 0, 7, 0, 0, 0, time.UTC), "04:00"},
 			result: exp,
 		},
 		{
 			name:   "repeated values on input don't get duplicated after decoding",
-			params: []any{"03:00;15:00;01:00;07:00;04:00;01:00"},
+			params: []interface{}{"03:00;15:00;01:00;07:00;04:00;01:00"},
 			result: exp,
 		},
 	}
@@ -903,7 +903,7 @@ func TestClearUnique(t *testing.T) {
 	// be stopped on s.Clear()
 	assert.Equal(t, 1, counter)
 
-	s.tags.Range(func(key, value any) bool {
+	s.tags.Range(func(key, value interface{}) bool {
 		assert.FailNow(t, "map should be empty")
 		return true
 	})
@@ -981,18 +981,18 @@ func TestScheduler_Stop(t *testing.T) {
 	})
 	t.Run("waits for jobs to finish processing before returning .Stop()", func(t *testing.T) {
 		t.Parallel()
-		i := int32(0)
+		i := atomic.NewInt64(0)
 
 		s := NewScheduler(time.UTC)
 		s.Every(10).Second().Do(func() {
 			time.Sleep(2 * time.Second)
-			atomic.AddInt32(&i, 1)
+			i.Add(1)
 		})
 		s.StartAsync()
 		time.Sleep(time.Second) // enough time for job to run
 		s.Stop()
 
-		assert.EqualValues(t, 1, atomic.LoadInt32(&i))
+		assert.EqualValues(t, 1, i.Load())
 	})
 	t.Run("stops a running scheduler calling .Stop()", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
@@ -1195,7 +1195,7 @@ func TestScheduler_CalculateNextRun(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s := NewScheduler(time.UTC)
 			s.time = ft
-			tc.job.runStartCount = &atomic.Int64{}
+			tc.job.runStartCount = atomic.NewInt64(0)
 			got := s.durationToNextRun(tc.job.LastRun(), tc.job).duration
 			assert.Equalf(t, tc.wantTimeUntilNextRun, got, fmt.Sprintf("expected %s / got %s", tc.wantTimeUntilNextRun.String(), got.String()))
 		})
@@ -1360,7 +1360,7 @@ func TestRunJobsWithLimit(t *testing.T) {
 			require.LessOrEqual(t, counter, 1)
 		}
 
-		s.tags.Range(func(key, value any) bool {
+		s.tags.Range(func(key, value interface{}) bool {
 			assert.FailNow(t, "map should be empty")
 			return true
 		})
@@ -1443,13 +1443,13 @@ func TestScheduler_SingletonMode(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			s := NewScheduler(time.UTC)
-			var trigger int32
+			trigger := atomic.NewInt64(0)
 
 			j, err := s.Every("100ms").SingletonMode().Do(func() {
-				if atomic.LoadInt32(&trigger) == 1 {
+				if trigger.Load() == 1 {
 					t.Fatal("Restart should not occur")
 				}
-				atomic.AddInt32(&trigger, 1)
+				trigger.Add(1)
 				time.Sleep(300 * time.Millisecond)
 			})
 			require.NoError(t, err)
@@ -1480,13 +1480,13 @@ func TestScheduler_SingletonModeAll(t *testing.T) {
 			s := NewScheduler(time.UTC)
 			s.SingletonModeAll()
 
-			var trigger int32
+			trigger := atomic.NewInt64(0)
 
 			j, err := s.Every("100ms").Do(func() {
-				if atomic.LoadInt32(&trigger) == 1 {
+				if trigger.Load() == 1 {
 					t.Fatal("Restart should not occur")
 				}
-				atomic.AddInt32(&trigger, 1)
+				trigger.Add(1)
 				time.Sleep(300 * time.Millisecond)
 			})
 			require.NoError(t, err)
@@ -1722,10 +1722,10 @@ func TestScheduler_MultipleTagsChained(t *testing.T) {
 func TestScheduler_DoParameterValidation(t *testing.T) {
 	testCases := []struct {
 		description string
-		parameters  []any
+		parameters  []interface{}
 	}{
-		{"less than expected", []any{"p1"}},
-		{"more than expected", []any{"p1", "p2", "p3"}},
+		{"less than expected", []interface{}{"p1"}},
+		{"more than expected", []interface{}{"p1", "p2", "p3"}},
 	}
 
 	for _, tc := range testCases {
@@ -2422,15 +2422,15 @@ func TestScheduler_MultipleAtTime(t *testing.T) {
 func TestScheduler_DoWithJobDetails(t *testing.T) {
 	testCases := []struct {
 		description   string
-		jobFunc       any
-		params        []any
+		jobFunc       interface{}
+		params        []interface{}
 		expectedError string
 	}{
-		{"no error", func(foo, bar string, job Job) {}, []any{"foo", "bar"}, ""},
-		{"too few params", func(foo, bar string, job Job) {}, []any{"foo"}, ErrWrongParams.Error()},
-		{"too many params", func(foo, bar string, job Job) {}, []any{"foo", "bar", "baz"}, ErrWrongParams.Error()},
-		{"jobFunc doesn't have Job param", func(foo, bar string) {}, []any{"foo"}, ErrDoWithJobDetails.Error()},
-		{"jobFunc has Job param but not last param", func(job Job, foo, bar string) {}, []any{"foo", "bar"}, ErrDoWithJobDetails.Error()},
+		{"no error", func(foo, bar string, job Job) {}, []interface{}{"foo", "bar"}, ""},
+		{"too few params", func(foo, bar string, job Job) {}, []interface{}{"foo"}, ErrWrongParams.Error()},
+		{"too many params", func(foo, bar string, job Job) {}, []interface{}{"foo", "bar", "baz"}, ErrWrongParams.Error()},
+		{"jobFunc doesn't have Job param", func(foo, bar string) {}, []interface{}{"foo"}, ErrDoWithJobDetails.Error()},
+		{"jobFunc has Job param but not last param", func(job Job, foo, bar string) {}, []interface{}{"foo", "bar"}, ErrDoWithJobDetails.Error()},
 	}
 
 	for _, tc := range testCases {
@@ -2524,7 +2524,7 @@ func TestScheduler_ChainOrder(t *testing.T) {
 	func2 := func() { panic("func 2 not implemented") }
 	func3 := func() { panic("func 3 not implemented") }
 
-	funcs := []any{func1, func2, func3}
+	funcs := []interface{}{func1, func2, func3}
 
 	_, err := s.Tag("1").SingletonMode().Milliseconds().EveryRandom(100, 200).Do(func1)
 	require.NoError(t, err)


### PR DESCRIPTION
### What does this do?
moves support back down to golang 1.16.

the only features from go 1.20 that were being used were the new atomic values (which the uber package previously provided) and `any` instead of `interface{}`, but not actually using any generics here.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #483 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
