### PR TITLE
add Job.PreivousRun() to expose the job run time prior to LastRun()

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -84,6 +84,14 @@ func ExampleJob_NextRun() {
 	s.StartAsync()
 }
 
+func ExampleJob_PreviousRun() {
+	s := gocron.NewScheduler(time.UTC)
+	job, _ := s.Every(1).Second().Do(task)
+	s.StartAsync()
+
+	fmt.Println("Previous run:", job.PreviousRun())
+}
+
 func ExampleJob_RunCount() {
 	s := gocron.NewScheduler(time.UTC)
 	job, _ := s.Every(1).Second().Do(task)

--- a/job.go
+++ b/job.go
@@ -24,6 +24,7 @@ type Job struct {
 	atTimes           []time.Duration // optional time(s) at which this Job runs when interval is day
 	startAtTime       time.Time       // optional time at which the Job starts
 	error             error           // error related to Job
+	previousRun       time.Time       // datetime of the run before last run
 	lastRun           time.Time       // datetime of last run
 	nextRun           time.Time       // datetime of next run
 	scheduledWeekdays []time.Weekday  // Specific days of the week to start on
@@ -435,6 +436,7 @@ func (j *Job) LastRun() time.Time {
 }
 
 func (j *Job) setLastRun(t time.Time) {
+	j.previousRun = j.lastRun
 	j.lastRun = t
 }
 
@@ -450,6 +452,13 @@ func (j *Job) setNextRun(t time.Time) {
 	defer j.mu.Unlock()
 	j.nextRun = t
 	j.jobFunction.jobFuncNextRun = t
+}
+
+// PreviousRun returns the job run time previous to LastRun
+func (j *Job) PreviousRun() time.Time {
+	j.mu.RLock()
+	defer j.mu.RUnlock()
+	return j.previousRun
 }
 
 // RunCount returns the number of times the job has been started
@@ -498,6 +507,7 @@ func (j *Job) copy() Job {
 		error:             j.error,
 		lastRun:           j.lastRun,
 		nextRun:           j.nextRun,
+		previousRun:       j.previousRun,
 		scheduledWeekdays: j.scheduledWeekdays,
 		daysOfTheMonth:    j.daysOfTheMonth,
 		tags:              j.tags,

--- a/scheduler.go
+++ b/scheduler.go
@@ -600,6 +600,9 @@ func (s *Scheduler) runContinuous(job *Job) {
 	if !job.getStartsImmediately() {
 		job.setStartsImmediately(true)
 	} else {
+		//if job.neverRan() {
+		//	job.setLastRun(s.now())
+		//}
 		s.run(job)
 	}
 	nr := next.dateTime.Sub(s.now())


### PR DESCRIPTION
### What does this do?

adds a new method to Job: `PreivousRun()` to expose the job run time prior to `LastRun()`

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
