### PR TITLE
provide a better panic message when no jobs in scheduler and start blocking called

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -776,6 +776,7 @@ func ExampleScheduler_Stop() {
 	fmt.Println(s.IsRunning())
 
 	s = gocron.NewScheduler(time.UTC)
+	_, _ = s.Every(1).Second().Do(task)
 
 	go func() {
 		time.Sleep(1 * time.Second)

--- a/scheduler.go
+++ b/scheduler.go
@@ -77,7 +77,12 @@ func (s *Scheduler) SetMaxConcurrentJobs(n int, mode limitMode) {
 
 // StartBlocking starts all jobs and blocks the current thread.
 // This blocking method can be stopped with Stop() from a separate goroutine.
+//
+// There must be at least 1 job in the scheduler or a panic will occur.
 func (s *Scheduler) StartBlocking() {
+	if len(s.Jobs()) == 0 {
+		panic("gocron: scheduler must have at least 1 job before calling StartBlocking")
+	}
 	s.StartAsync()
 	s.startBlockingStopChanMutex.Lock()
 	s.startBlockingStopChan = make(chan struct{}, 1)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -996,6 +996,8 @@ func TestScheduler_Stop(t *testing.T) {
 	})
 	t.Run("stops a running scheduler calling .Stop()", func(t *testing.T) {
 		s := NewScheduler(time.UTC)
+		_, err := s.Every(1).Second().Do(func() {})
+		require.NoError(t, err)
 
 		go func() {
 			time.Sleep(time.Second)
@@ -2690,4 +2692,12 @@ func TestScheduler_WithDistributedLocker_With_Name(t *testing.T) {
 			assert.Len(t, results, tc.expected)
 		})
 	}
+}
+
+func TestScheduler_StartBlocking(t *testing.T) {
+	t.Run("panics if no jobs are added", func(t *testing.T) {
+		s := NewScheduler(time.UTC)
+		expected := "gocron: scheduler must have at least 1 job before calling StartBlocking"
+		assert.PanicsWithValue(t, expected, s.StartBlocking)
+	})
 }


### PR DESCRIPTION
### What does this do?
the code would panic already. in this case we'll pre-empt it and panic with a useful message so the caller knows why

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #500 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
