### PR TITLE
fix: panic: runtime error: integer divide by zero

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -756,7 +756,7 @@ func ExampleScheduler_StartAt() {
 	s.StartBlocking()
 }
 
-func ExampleScheduler_StartAt_AfterTaskStart() {
+func ExampleScheduler_StartAt_afterTaskStart() {
 	s := gocron.NewScheduler(time.UTC)
 	_, _ = s.Every(5).Seconds().Do(task)
 	s.StartAt(time.Now().Add(10 * time.Second))

--- a/example_test.go
+++ b/example_test.go
@@ -756,6 +756,13 @@ func ExampleScheduler_StartAt() {
 	s.StartBlocking()
 }
 
+func ExampleScheduler_StartAt_AfterTaskStart() {
+	s := gocron.NewScheduler(time.UTC)
+	_, _ = s.Every(5).Seconds().Do(task)
+	s.StartAt(time.Now().Add(10 * time.Second))
+	s.StartBlocking()
+}
+
 func ExampleScheduler_StartBlocking() {
 	s := gocron.NewScheduler(time.UTC)
 	_, _ = s.Every(3).Seconds().Do(task)

--- a/scheduler.go
+++ b/scheduler.go
@@ -1043,6 +1043,7 @@ func (s *Scheduler) GetAllTags() []string {
 // StartAt schedules the next run of the Job. If this time is in the past, the configured interval will be used
 // to calculate the next future time
 func (s *Scheduler) StartAt(t time.Time) *Scheduler {
+	s.inScheduleChain = true
 	job := s.getCurrentJob()
 	job.setStartAtTime(t)
 	job.startsImmediately = false

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1108,6 +1108,22 @@ func TestScheduler_StartAt(t *testing.T) {
 
 		assert.Equal(t, dt.Add(time.Hour*168).Truncate(time.Second), job.NextRun())
 	})
+
+	t.Run("StartAt() called after starting a task", func(t *testing.T) {
+		s := NewScheduler(time.UTC)
+
+		dt := time.Now().UTC().Add(time.Second)
+		job, err := s.Every(1).Week().Do(func() {})
+		s.StartAt(dt)
+		require.NoError(t, err)
+
+		s.StartAsync()
+		assert.Equal(t, dt, job.NextRun())
+		time.Sleep(time.Millisecond * 1500)
+		s.Stop()
+
+		assert.Equal(t, dt.Add(time.Hour*168).Truncate(time.Second), job.NextRun())
+	})
 }
 
 func TestScheduler_CalculateNextRun(t *testing.T) {


### PR DESCRIPTION
"Do" function triggers "doCommon" function that sets "inScheduleChain" to false. In "getCurrentJob", if "inScheduleChain" is false, then a new job will be added to a slice and the current job will be the last element of the slice. Therefore, after "Do" function runs, "StartAt" will try to obtain the current job. Since "inScheduleChain" is false, a new job with interval 0 will be added and returned as the current job in "StartAt" function. After this interval 0 will produce "duration" to be 0 and "panic: runtime error: integer divide by zero".

### What does this do?


### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves https://github.com/go-co-op/gocron/issues/486

### List any changes that modify/break current functionality


### Have you included tests for your changes?
Yes


### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
