### PR TITLE
chore: don't do codeql scanning on push for dependabot branches

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,7 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    branches-ignore: "dependabot/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,8 @@ on:
     branches: [ main ]
     branches-ignore: "dependabot/**"
   pull_request:
+    paths-ignore:
+      - '**.md'
     # The branches below must be a subset of the branches above
     branches: [ main ]
   schedule:


### PR DESCRIPTION
### What does this do?
https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#scanning-on-push

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
