### PR TITLE
add new RegisterEventListeners using new EventListener type

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -72,7 +72,14 @@ func runJob(f jobFunction) {
 	f.runStartCount.Add(1)
 	f.isRunning.Store(true)
 	callJobFunc(f.eventListeners.onBeforeJobExecution)
-	callJobFuncWithParams(f.function, f.parameters)
+	_ = callJobFuncWithParams(f.eventListeners.beforeJobRuns, []interface{}{f.getName()})
+	err := callJobFuncWithParams(f.function, f.parameters)
+	if err != nil {
+		_ = callJobFuncWithParams(f.eventListeners.onError, []interface{}{f.getName(), err})
+	} else {
+		_ = callJobFuncWithParams(f.eventListeners.noError, []interface{}{f.getName()})
+	}
+	_ = callJobFuncWithParams(f.eventListeners.afterJobRuns, []interface{}{f.getName()})
 	callJobFunc(f.eventListeners.onAfterJobExecution)
 	f.isRunning.Store(false)
 	f.runFinishCount.Add(1)

--- a/job.go
+++ b/job.go
@@ -362,6 +362,8 @@ type EventListener func(j *Job)
 // BeforeJobRuns is called before the job is run
 func BeforeJobRuns(eventListenerFunc func(jobName string)) EventListener {
 	return func(j *Job) {
+		j.mu.Lock()
+		defer j.mu.Unlock()
 		j.eventListeners.beforeJobRuns = eventListenerFunc
 	}
 }
@@ -370,6 +372,8 @@ func BeforeJobRuns(eventListenerFunc func(jobName string)) EventListener {
 // This is called even when an error is returned
 func AfterJobRuns(eventListenerFunc func(jobName string)) EventListener {
 	return func(j *Job) {
+		j.mu.Lock()
+		defer j.mu.Unlock()
 		j.eventListeners.afterJobRuns = eventListenerFunc
 	}
 }
@@ -377,6 +381,8 @@ func AfterJobRuns(eventListenerFunc func(jobName string)) EventListener {
 // WhenJobReturnsError is called when the job returns an error
 func WhenJobReturnsError(eventListenerFunc func(jobName string, err error)) EventListener {
 	return func(j *Job) {
+		j.mu.Lock()
+		defer j.mu.Unlock()
 		j.eventListeners.onError = eventListenerFunc
 	}
 }
@@ -385,11 +391,14 @@ func WhenJobReturnsError(eventListenerFunc func(jobName string, err error)) Even
 // the function must accept a single parameter, which is an error
 func WhenJobReturnsNoError(eventListenerFunc func(jobName string)) EventListener {
 	return func(j *Job) {
+		j.mu.Lock()
+		defer j.mu.Unlock()
 		j.eventListeners.noError = eventListenerFunc
 	}
 }
 
 // RegisterEventListeners accepts EventListeners and registers them for the job
+// The event listeners are then called at the times described by each listener.
 func (j *Job) RegisterEventListeners(eventListeners ...EventListener) {
 	for _, el := range eventListeners {
 		el(j)

--- a/job.go
+++ b/job.go
@@ -574,7 +574,7 @@ func (j *Job) IsRunning() bool {
 func (j *Job) copy() Job {
 	return Job{
 		mu:                &jobMutex{},
-		jobFunction:       j.jobFunction.copy(),
+		jobFunction:       j.jobFunction,
 		interval:          j.interval,
 		duration:          j.duration,
 		unit:              j.unit,

--- a/job_test.go
+++ b/job_test.go
@@ -259,9 +259,11 @@ func TestJob_SetEventListeners(t *testing.T) {
 
 		job2, err := s.Every("100ms").Do(func() error { return fmt.Errorf("failed") })
 		require.NoError(t, err)
+		wg.Add(1)
 		job2.RegisterEventListeners(
 			AfterJobRuns(func(_ string) {
 				afterJobCallback = true
+				wg.Done()
 			}),
 			BeforeJobRuns(func(_ string) {
 				beforeJobCallback = true
@@ -273,9 +275,11 @@ func TestJob_SetEventListeners(t *testing.T) {
 
 		job3, err := s.Every("100ms").Do(func() {})
 		require.NoError(t, err)
+		wg.Add(1)
 		job3.RegisterEventListeners(
 			WhenJobReturnsNoError(func(_ string) {
 				noErrorCallback = true
+				wg.Done()
 			}),
 		)
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -1430,3 +1430,14 @@ func (s *Scheduler) StopBlockingChan() {
 func (s *Scheduler) WithDistributedLocker(l Locker) {
 	s.executor.distributedLocker = l
 }
+
+// RegisterEventListeners accepts EventListeners and registers them for all jobs
+// in the scheduler at the time this function is called.
+// The event listeners are then called at the times described by each listener.
+// If a new job is added, an additional call to this method, or the job specific
+// version must be executed in order for the new job to trigger event listeners.
+func (s *Scheduler) RegisterEventListeners(eventListeners ...EventListener) {
+	for _, job := range s.Jobs() {
+		job.RegisterEventListeners(eventListeners...)
+	}
+}

--- a/scheduler.go
+++ b/scheduler.go
@@ -605,9 +605,6 @@ func (s *Scheduler) runContinuous(job *Job) {
 	if !job.getStartsImmediately() {
 		job.setStartsImmediately(true)
 	} else {
-		//if job.neverRan() {
-		//	job.setLastRun(s.now())
-		//}
 		s.run(job)
 	}
 	nr := next.dateTime.Sub(s.now())


### PR DESCRIPTION
### What does this do?
deprecates the `SetEventListeners` function in favor of a more flexible function `RegisterEventListeners` that accepts a variadic list of `EventListener` to allow for expansion of event listeners in the future.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
relates to #515 

### List any changes that modify/break current functionality
deprecates the `SetEventListeners` function 

### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes

TODO: add ability to enable globally
