### PR TITLE
feat: handle pointer to func

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -127,6 +127,10 @@ func getFunctionName(fn interface{}) string {
 	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
 }
 
+func getFunctionNameOfPointer(fn interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(fn).Elem().Pointer()).Name()
+}
+
 func parseTime(t string) (hour, min, sec int, err error) {
 	var timeLayout string
 	switch {

--- a/scheduler.go
+++ b/scheduler.go
@@ -953,19 +953,14 @@ func (s *Scheduler) doCommon(jobFun interface{}, params ...interface{}) (*Job, e
 	if job.funcName != fname {
 		job.function = jobFun
 		if val != reflect.ValueOf(jobFun) {
-			job.function = reflect.ValueOf(jobFun).Elem().Interface()
+			job.function = val.Interface()
 		}
 
 		job.parameters = params
 		job.funcName = fname
 	}
 
-	f := reflect.ValueOf(jobFun)
-	if f != val {
-		f = f.Elem()
-	}
-
-	expectedParamLength := f.Type().NumIn()
+	expectedParamLength := val.Type().NumIn()
 	if job.runWithDetails {
 		expectedParamLength--
 	}
@@ -976,7 +971,7 @@ func (s *Scheduler) doCommon(jobFun interface{}, params ...interface{}) (*Job, e
 		return nil, job.error
 	}
 
-	if job.runWithDetails && f.Type().In(len(params)).Kind() != reflect.ValueOf(*job).Kind() {
+	if job.runWithDetails && val.Type().In(len(params)).Kind() != reflect.ValueOf(*job).Kind() {
 		s.RemoveByReference(job)
 		job.error = wrapOrError(job.error, ErrDoWithJobDetails)
 		return nil, job.error

--- a/scheduler.go
+++ b/scheduler.go
@@ -943,8 +943,10 @@ func (s *Scheduler) doCommon(jobFun interface{}, params ...interface{}) (*Job, e
 		return nil, ErrNotAFunction
 	}
 
-	fname := getFunctionName(jobFun)
-	if val != reflect.ValueOf(jobFun) {
+	var fname string
+	if val == reflect.ValueOf(jobFun) {
+		fname = getFunctionName(jobFun)
+	} else {
 		fname = getFunctionNameOfPointer(jobFun)
 	}
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -57,6 +57,24 @@ func TestImmediateExecution(t *testing.T) {
 	}
 }
 
+func TestExecutionWithPointerToFunc(t *testing.T) {
+	s := NewScheduler(time.UTC)
+	semaphore := make(chan bool)
+	fn := func() { semaphore <- true }
+
+	_, err := s.Every(1).Second().Do(&fn)
+	require.NoError(t, err)
+	s.StartAsync()
+	select {
+	case <-time.After(time.Second):
+		s.stop()
+		t.Fatal("job did not run immediately")
+	case <-semaphore:
+		// test passed
+		s.stop()
+	}
+}
+
 func TestScheduler_Every_InvalidInterval(t *testing.T) {
 	testCases := []struct {
 		description   string


### PR DESCRIPTION
Hi,
Merging this pull request can add the ability to pass the pointer of func in `Do()` method.
Example:
```go
fn := func() { fmt.Println("Hi") }
_, err := s.Every(1).Second().Do(&fn)
fmt.Println(err)
// nil

_, err = s.Every(1).Second().Do(fn)
fmt.Println(err)
// nil
```
I have added a test for that, and it works properly and is also backward compatible.
If you have any ideas or concerns regarding the PR, feel free to tell me.