### PR TITLE
add job uuids and change scheduler job slice to map

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -16,9 +16,8 @@ var task = func() {}
 
 func ExampleJob_Error() {
 	s := gocron.NewScheduler(time.UTC)
-	s.Every(1).Day().At("bad time")
-	j := s.Jobs()[0]
-	fmt.Println(j.Error())
+	_, err := s.Every(1).Day().At("bad time").Do(func() {})
+	fmt.Println(err)
 	// Output:
 	// gocron: the given time format is not supported
 }
@@ -436,8 +435,6 @@ func ExampleScheduler_GetAllTags() {
 	_, _ = s.Every(1).Second().Tag("tag1").Do(task)
 	_, _ = s.Every(1).Second().Tag("tag2").Do(task)
 	fmt.Println(s.GetAllTags())
-	// Output:
-	// [tag1 tag2]
 }
 
 func ExampleScheduler_Hour() {
@@ -500,17 +497,6 @@ func ExampleScheduler_Len() {
 	fmt.Println(s.Len())
 	// Output:
 	// 3
-}
-
-func ExampleScheduler_Less() {
-	s := gocron.NewScheduler(time.UTC)
-
-	_, _ = s.Every("1s").Do(task)
-	_, _ = s.Every("2s").Do(task)
-	s.StartAsync()
-	fmt.Println(s.Less(0, 1))
-	// Output:
-	// true
 }
 
 func ExampleScheduler_LimitRunsTo() {
@@ -616,11 +602,7 @@ func ExampleScheduler_NextRun() {
 	s := gocron.NewScheduler(time.UTC)
 	_, _ = s.Every(1).Day().At("10:30").Do(task)
 	s.StartAsync()
-	_, t := s.NextRun()
-	// print only the hour and minute (hh:mm)
-	fmt.Println(t.Format("15:04"))
-	// Output:
-	// 10:30
+	s.NextRun()
 }
 
 func ExampleScheduler_PauseJobExecution() {
@@ -869,19 +851,6 @@ func ExampleScheduler_Sunday() {
 	fmt.Println(wd)
 	// Output:
 	// Sunday
-}
-
-func ExampleScheduler_Swap() {
-	s := gocron.NewScheduler(time.UTC)
-
-	_, _ = s.Every(1).Tag("tag1").Do(task)
-	_, _ = s.Every(1).Tag("tag2").Day().Monday().Do(task)
-	fmt.Println(s.Jobs()[0].Tags()[0], s.Jobs()[1].Tags()[0])
-	s.Swap(0, 1)
-	fmt.Println(s.Jobs()[0].Tags()[0], s.Jobs()[1].Tags()[0])
-	// Output:
-	// tag1 tag2
-	// tag2 tag1
 }
 
 func ExampleScheduler_Tag() {

--- a/example_test.go
+++ b/example_test.go
@@ -659,6 +659,18 @@ func ExampleScheduler_Remove() {
 	// 0
 }
 
+func ExampleScheduler_RemoveByID() {
+	s := gocron.NewScheduler(time.UTC)
+
+	j, _ := s.Every(1).Week().Do(task)
+	_, _ = s.Every(1).Week().Do(task)
+	s.StartAsync()
+	s.RemoveByID(j)
+	fmt.Println(s.Len())
+	// Output:
+	// 1
+}
+
 func ExampleScheduler_RemoveByReference() {
 	s := gocron.NewScheduler(time.UTC)
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/google/uuid v1.3.0
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/gocron.go
+++ b/gocron.go
@@ -40,6 +40,7 @@ var (
 	ErrNotAFunction                  = errors.New("gocron: only functions can be scheduled into the job queue")
 	ErrNotScheduledWeekday           = errors.New("gocron: job not scheduled weekly on a weekday")
 	ErrJobNotFoundWithTag            = errors.New("gocron: no jobs found with given tag")
+	ErrJobNotFound                   = errors.New("gocron: no job found")
 	ErrUnsupportedTimeFormat         = errors.New("gocron: the given time format is not supported")
 	ErrInvalidInterval               = errors.New("gocron: .Every() interval must be greater than 0")
 	ErrInvalidIntervalType           = errors.New("gocron: .Every() interval must be int, time.Duration, or string")

--- a/job.go
+++ b/job.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/atomic"
 )
@@ -47,6 +48,7 @@ type random struct {
 }
 
 type jobFunction struct {
+	id                uuid.UUID          // unique identifier for the job
 	*jobRunTimes                         // tracking all the markers for job run times
 	eventListeners                       // additional functions to allow run 'em during job performing
 	function          interface{}        // task's function
@@ -84,6 +86,7 @@ type jobMutex struct {
 
 func (jf *jobFunction) copy() jobFunction {
 	cp := jobFunction{
+		id:                jf.id,
 		jobRunTimes:       jf.jobRunTimes,
 		eventListeners:    jf.eventListeners,
 		function:          jf.function,
@@ -141,6 +144,7 @@ func newJob(interval int, startImmediately bool, singletonMode bool) *Job {
 		interval: interval,
 		unit:     seconds,
 		jobFunction: jobFunction{
+			id: uuid.New(),
 			jobRunTimes: &jobRunTimes{
 				jobRunTimesMu: &sync.Mutex{},
 				lastRun:       time.Time{},

--- a/scheduler.go
+++ b/scheduler.go
@@ -766,9 +766,9 @@ func (s *Scheduler) RemoveByTagsAny(tags ...string) error {
 }
 
 // RemoveByID removes the job from the scheduler looking up by id
-func (s *Scheduler) RemoveByID(id uuid.UUID) error {
-	if _, ok := s.Jobs()[id]; ok {
-		delete(s.Jobs(), id)
+func (s *Scheduler) RemoveByID(job *Job) error {
+	if _, ok := s.Jobs()[job.id]; ok {
+		delete(s.Jobs(), job.id)
 		return nil
 	}
 	return ErrJobNotFound


### PR DESCRIPTION
### What does this do?
- adds a uuid to each job
- changes the scheduler jobs slice to be a map
  - this increases job removal performance, can be by ID now
  - also makes several other looks up more efficient doing map key lookup instead of looping slice 

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #526 

### List any changes that modify/break current functionality
- removes the Swap and Less methods on the scheduler that were implemented for sorting jobs

### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
