### PR TITLE
more than 1 day before last day of month gets stuck in a loop

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -321,7 +321,7 @@ func calculateNextRunForLastDayOfMonth(s *Scheduler, job *Job, lastRun time.Time
 	// last run occurred before the end of the month.
 	addMonth := job.getInterval()
 	atTime := job.getAtTime(lastRun)
-	if testDate := lastRun.AddDate(0, 0, 1); testDate.Month() != lastRun.Month() &&
+	if testDate := lastRun.AddDate(0, 0, -dayBeforeLastOfMonth); testDate.Month() != lastRun.Month() &&
 		!s.roundToMidnightAndAddDSTAware(lastRun, atTime).After(lastRun) {
 		// Our last run was on the last day of this month.
 		addMonth++


### PR DESCRIPTION
### What does this do?
a bug was introduced in #542 that this PR fixes. when calculating the next run it didn't take into account multiple negative days and only considered the last day of the month

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #554 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
