### PR TITLE
fix: modify the boundary of max_concurrent_jobs

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -222,7 +222,7 @@ func (e *executor) run() {
 				if e.limitModeMaxRunningJobs > 0 {
 					switch e.limitMode {
 					case RescheduleMode:
-						if e.limitModeRunningJobs.Load() < int64(e.limitModeMaxRunningJobs) {
+						if e.limitModeRunningJobs.Load() <= int64(e.limitModeMaxRunningJobs) {
 							select {
 							case e.limitModeQueue <- f:
 							case <-e.ctx.Done():


### PR DESCRIPTION
### summary

when we set the maximum concurrency to 10, the final concurrency to 9 ? 😅

😁 I looked at the implementation of other golang libraries, and the `maxXXXX` usually contains the largest value.  

I think it makes more sense.  

**refer**

https://github.com/redis/go-redis/blob/master/cluster.go#L909C37-L909C49

https://github.com/golang/sync/blob/master/semaphore/semaphore.go#L42

https://github.com/golang/sync/blob/master/errgroup/errgroup.go#L131