### PR TITLE
feat: add election leader

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -166,6 +166,8 @@ func (e *executor) runJob(f jobFunction) {
 			if err != nil {
 				return
 			}
+			runJob(f)
+			return
 		}
 		if e.distributedLocker != nil {
 			l, err := e.distributedLocker.Lock(f.ctx, lockKey)
@@ -197,6 +199,8 @@ func (e *executor) runJob(f jobFunction) {
 				}
 				_ = l.Unlock(f.ctx)
 			}()
+			runJob(f)
+			return
 		}
 		runJob(f)
 	case singletonMode:

--- a/executor.go
+++ b/executor.go
@@ -54,8 +54,8 @@ type executor struct {
 	limitModeRunningJobs    *atomic.Int64    // tracks the count of running jobs to check against the max
 	stopped                 *atomic.Bool     // allow workers to drain the buffered limitModeQueue
 
-	distributedLocker   Locker   // support running jobs across multiple instances
-	distributedElection Election // support running jobs across multiple instances
+	distributedLocker  Locker  // support running jobs across multiple instances
+	distributedElector Elector // support running jobs across multiple instances
 }
 
 func newExecutor() executor {
@@ -161,8 +161,8 @@ func (e *executor) runJob(f jobFunction) {
 		if lockKey == "" {
 			lockKey = f.funcName
 		}
-		if e.distributedElection != nil {
-			err := e.distributedElection.IsLeader(e.ctx)
+		if e.distributedElector != nil {
+			err := e.distributedElector.IsLeader(e.ctx)
 			if err != nil {
 				return
 			}

--- a/locker.go
+++ b/locker.go
@@ -22,10 +22,9 @@ type Lock interface {
 	Unlock(ctx context.Context) error
 }
 
-// Election the leader instance can run the jobs only.
-type Election interface {
-	// IsLeader if an error is returned by IsLeader, the job will not be scheduled.
-	// IsLeader is a non-blocking implementation. it will start a thread internally to elect
-	// and update the status to a variable atomically. IsLeader() returns the election status only.
+// Elector determines the leader from instances asking to be the leader. Only
+// the leader runs jobs. If the leader goes down, a new leader will be elected.
+type Elector interface {
+	// IsLeader should return an error if the job should not be scheduled and nil if the job should be scheduled.
 	IsLeader(ctx context.Context) error
 }

--- a/locker.go
+++ b/locker.go
@@ -21,3 +21,11 @@ type Locker interface {
 type Lock interface {
 	Unlock(ctx context.Context) error
 }
+
+// Election the leader instance can run the jobs only.
+type Election interface {
+	// IsLeader if an error is returned by IsLeader, the job will not be scheduled.
+	// IsLeader is a non-blocking implementation. it will start a thread internally to elect
+	// and update the status to a variable atomically. IsLeader() returns the election status only.
+	IsLeader(ctx context.Context) error
+}

--- a/scheduler.go
+++ b/scheduler.go
@@ -1495,14 +1495,14 @@ func (s *Scheduler) WithDistributedLocker(l Locker) {
 
 // WithDistributedElector prevents the same job from being run more than once
 // when multiple schedulers are trying to schedule the same job, by allowing only
-// the leader to run jobs. Non-leaders wait until the leader instance goes down 
+// the leader to run jobs. Non-leaders wait until the leader instance goes down
 // and then a new leader is elected.
 //
 // Compared with the distributed lock, the election is the same as leader/follower framework.
 // All jobs are only scheduled and execute on the leader scheduler instance. Only when the leader scheduler goes down
 // and one of the scheduler instances is successfully elected, then the new leader scheduler instance can schedule jobs.
 func (s *Scheduler) WithDistributedElector(e Elector) {
-	s.executor.distributedElection = el
+	s.executor.distributedElector = e
 }
 
 // RegisterEventListeners accepts EventListeners and registers them for all jobs

--- a/scheduler.go
+++ b/scheduler.go
@@ -1493,17 +1493,15 @@ func (s *Scheduler) WithDistributedLocker(l Locker) {
 	s.executor.distributedLocker = l
 }
 
-// WithDistributedElection prevents the same job from being run more than once
-// when multiple schedulers are trying to schedule the same job.
+// WithDistributedElector prevents the same job from being run more than once
+// when multiple schedulers are trying to schedule the same job, by allowing only
+// the leader to run jobs. Non-leaders wait until the leader instance goes down 
+// and then a new leader is elected.
 //
-// Use the election component to elect the leader, In many instances, only there is only one leader instance,
-// the other instances are backup instances. only the leader scheduler instance can schedule the jobs.
-// Non-leader instance cannot schedule the jobs.
-//
-// Compared with the distributed lock, the election is the same as leader/follower (master/backup) framework.
-// All jobs are only scheduled and execute on the leader scheduler instance. Only when the leader scheduler instance hangs up,
-// and one of the scheduler instances is successfully elected, the new leader scheduler instance can schedule the jobs.
-func (s *Scheduler) WithDistributedElection(el Election) {
+// Compared with the distributed lock, the election is the same as leader/follower framework.
+// All jobs are only scheduled and execute on the leader scheduler instance. Only when the leader scheduler goes down
+// and one of the scheduler instances is successfully elected, then the new leader scheduler instance can schedule jobs.
+func (s *Scheduler) WithDistributedElector(e Elector) {
 	s.executor.distributedElection = el
 }
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -1493,6 +1493,20 @@ func (s *Scheduler) WithDistributedLocker(l Locker) {
 	s.executor.distributedLocker = l
 }
 
+// WithDistributedElection prevents the same job from being run more than once
+// when multiple schedulers are trying to schedule the same job.
+//
+// Use the election component to elect the leader, In many instances, only there is only one leader instance,
+// the other instances are backup instances. only the leader scheduler instance can schedule the jobs.
+// Non-leader instance cannot schedule the jobs.
+//
+// Compared with the distributed lock, the election is the same as an leader/follower (master/backup) framework.
+// All jobs are only scheduled and execute on the leader scheduler instance. Only when the leader scheduler instance hangs up,
+// and one of the scheduler instances is successfully elected, the new leader scheduler instance can schedule the jobs.
+func (s *Scheduler) WithDistributedElection(el Election) {
+	s.executor.distributedElection = el
+}
+
 // RegisterEventListeners accepts EventListeners and registers them for all jobs
 // in the scheduler at the time this function is called.
 // The event listeners are then called at the times described by each listener.

--- a/scheduler.go
+++ b/scheduler.go
@@ -1500,7 +1500,7 @@ func (s *Scheduler) WithDistributedLocker(l Locker) {
 // the other instances are backup instances. only the leader scheduler instance can schedule the jobs.
 // Non-leader instance cannot schedule the jobs.
 //
-// Compared with the distributed lock, the election is the same as an leader/follower (master/backup) framework.
+// Compared with the distributed lock, the election is the same as leader/follower (master/backup) framework.
 // All jobs are only scheduled and execute on the leader scheduler instance. Only when the leader scheduler instance hangs up,
 // and one of the scheduler instances is successfully elected, the new leader scheduler instance can schedule the jobs.
 func (s *Scheduler) WithDistributedElection(el Election) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2,6 +2,7 @@ package gocron
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -2850,4 +2851,69 @@ func TestDataRace(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 	sut.Stop()
+}
+
+var _ Election = (*election)(nil)
+
+type election struct {
+	isLeader bool
+}
+
+func (e *election) IsLeader(_ context.Context) error {
+	if e.isLeader {
+		return nil
+	}
+	return errors.New("is not leader")
+}
+
+func (e *election) setLeader() {
+	e.isLeader = true
+}
+
+func TestScheduler_EnableDistributedElection(t *testing.T) {
+	runTestWithDistributedElection(t, 0)
+}
+
+func TestScheduler_EnableDistributedElectionWithMaxConcurrent(t *testing.T) {
+	runTestWithDistributedElection(t, 1)
+}
+
+func runTestWithDistributedElection(t *testing.T, maxConcurrentJobs int) {
+	resultChan := make(chan int, 20)
+	f := func(schedulerInstance int) {
+		resultChan <- schedulerInstance
+	}
+
+	leaderIndex := 0
+	schedulers := make([]*Scheduler, 0)
+	for i := 0; i < 3; i++ {
+		el := &election{}
+		if i == leaderIndex {
+			el.setLeader()
+		}
+
+		s := NewScheduler(time.UTC)
+		s.WithDistributedElection(el)
+		if maxConcurrentJobs > 0 {
+			s.SetMaxConcurrentJobs(maxConcurrentJobs, WaitMode)
+		}
+		_, err := s.Every("50ms").Do(f, i)
+		require.NoError(t, err)
+		schedulers = append(schedulers, s)
+	}
+	for i := range schedulers {
+		schedulers[i].StartAsync()
+	}
+	time.Sleep(530 * time.Millisecond)
+	for i := range schedulers {
+		schedulers[i].Stop()
+	}
+	close(resultChan)
+
+	// 10 <- len <- 12
+	assert.Greater(t, len(resultChan), 10)
+	assert.Less(t, len(resultChan), 12)
+	for r := range resultChan {
+		assert.Equal(t, leaderIndex, r)
+	}
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2853,32 +2853,32 @@ func TestDataRace(t *testing.T) {
 	sut.Stop()
 }
 
-var _ Election = (*election)(nil)
+var _ Elector = (*elector)(nil)
 
-type election struct {
+type elector struct {
 	isLeader bool
 }
 
-func (e *election) IsLeader(_ context.Context) error {
+func (e *elector) IsLeader(_ context.Context) error {
 	if e.isLeader {
 		return nil
 	}
 	return errors.New("is not leader")
 }
 
-func (e *election) setLeader() {
+func (e *elector) setLeader() {
 	e.isLeader = true
 }
 
-func TestScheduler_EnableDistributedElection(t *testing.T) {
-	runTestWithDistributedElection(t, 0)
+func TestScheduler_EnableDistributedElector(t *testing.T) {
+	runTestWithDistributedElector(t, 0)
 }
 
-func TestScheduler_EnableDistributedElectionWithMaxConcurrent(t *testing.T) {
-	runTestWithDistributedElection(t, 1)
+func TestScheduler_EnableDistributedElectorWithMaxConcurrent(t *testing.T) {
+	runTestWithDistributedElector(t, 1)
 }
 
-func runTestWithDistributedElection(t *testing.T, maxConcurrentJobs int) {
+func runTestWithDistributedElector(t *testing.T, maxConcurrentJobs int) {
 	resultChan := make(chan int, 20)
 	f := func(schedulerInstance int) {
 		resultChan <- schedulerInstance
@@ -2887,13 +2887,13 @@ func runTestWithDistributedElection(t *testing.T, maxConcurrentJobs int) {
 	leaderIndex := 0
 	schedulers := make([]*Scheduler, 0)
 	for i := 0; i < 3; i++ {
-		el := &election{}
+		el := &elector{}
 		if i == leaderIndex {
 			el.setLeader()
 		}
 
 		s := NewScheduler(time.UTC)
-		s.WithDistributedElection(el)
+		s.WithDistributedElector(el)
 		if maxConcurrentJobs > 0 {
 			s.SetMaxConcurrentJobs(maxConcurrentJobs, WaitMode)
 		}


### PR DESCRIPTION
## summary

Sometimes, we need gocron to support active-standby mode. Only the active instance can run jobs, and other instances are just backup instances. Only when there is a problem with the master instance can other backup instances run jobs.

we can use  libs to implement election interface, e.g. `etcd election`、`k8s leaderelection`、`consul`、 `zk` and `redis lock`.  😁

It is recommended that gocron can give users more choices, allowing users to choose distributed locks and distributed election solutions according to their needs. 

### election vs lock

Of course, the distributed lock solution is also very good, each gocron instances try to acquire lock, each gocron instaces can run jobs with probability.

The advantage of election is that all tasks are executed on one instance, and more business optimization operations can be done, such as simpler code, local cache, connection pool, etc. 😁

![image](https://github.com/go-co-op/gocron/assets/3785409/4e1485ad-a8ee-4054-a8ed-192ad40f8fe9)

Aftger the server-1 crashes and exits abnormally，the server-2 elected as leader. the server-2 can schedule all jobs.

![image](https://github.com/go-co-op/gocron/assets/3785409/1dbf8a50-af31-481b-8c3c-1053140d2004)
