### PR TITLE
docs: fix WaitMode and Milliseconds documentation

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -32,7 +32,6 @@ const (
 	//    	   // blocked trying to send to the buffered channel
 	//         time.Sleep(10 * time.Minute)
 	//     })
-
 	WaitMode
 )
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -1108,12 +1108,12 @@ func (s *Scheduler) setUnit(unit schedulingUnit) {
 	job.setUnit(unit)
 }
 
-// Millisecond sets the unit with seconds
+// Millisecond sets the unit with milliseconds
 func (s *Scheduler) Millisecond() *Scheduler {
 	return s.Milliseconds()
 }
 
-// Milliseconds sets the unit with seconds
+// Milliseconds sets the unit with milliseconds
 func (s *Scheduler) Milliseconds() *Scheduler {
 	s.setUnit(milliseconds)
 	return s


### PR DESCRIPTION
### What does this do?
* Remove line break between docs and `WaitMode` enum, so it shows up in pkg.go.dev documentation.
* Fixes typo in docs for `Scheduler.Millisecond()` and `Scheduler.Milliseconds()` functions.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
N/A

### List any changes that modify/break current functionality
N/A

### Have you included tests for your changes?
N/A

### Did you document any new/modified functionality?
N/A

### Notes
