### PR TITLE
fix removing a job not stopping with limit mode

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -128,7 +128,11 @@ func (e *executor) limitModeRunner() {
 			return
 		case jf := <-e.limitModeQueue:
 			if !e.stopped.Load() {
-				e.runJob(jf)
+				select {
+				case <-jf.ctx.Done():
+				default:
+					e.runJob(jf)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What does this do?
before running a job in the limit mode runner, we need to check that the context isn't cancelled. If it is, obviously don't run the job

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
