### PR TITLE
fix Scheduler.NextRun() not returning the correct value (#574)

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -520,8 +520,15 @@ func (s *Scheduler) NextRun() (*Job, time.Time) {
 
 	var jobID uuid.UUID
 	var nearestRun time.Time
+	flag := false
 	for _, job := range s.jobsMap() {
 		nr := job.NextRun()
+		if !flag && s.now().Before(nr) {
+			nearestRun = nr
+			jobID = job.id
+			flag = true
+			continue
+		}
 		if nr.Before(nearestRun) && s.now().Before(nr) {
 			nearestRun = nr
 			jobID = job.id


### PR DESCRIPTION
### What does this do?
Initialize nearestRun to the next execution time of the first Job in map.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves #574

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
