### PR TITLE
fix: set multi-weekdays bug about issue-590

### DIFF
--- a/job.go
+++ b/job.go
@@ -482,6 +482,9 @@ func (j *Job) Weekdays() []time.Weekday {
 	if len(j.scheduledWeekdays) == 0 {
 		return []time.Weekday{time.Sunday}
 	}
+	sort.Slice(j.scheduledWeekdays, func(i, k int) bool {
+		return j.scheduledWeekdays[i] < j.scheduledWeekdays[k]
+	})
 
 	return j.scheduledWeekdays
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -393,8 +393,8 @@ func (s *Scheduler) calculateWeeks(job *Job, lastRun time.Time) nextRun {
 
 func (s *Scheduler) calculateTotalDaysDifference(lastRun time.Time, daysToWeekday int, job *Job) int {
 	if job.getInterval() > 1 {
-		// just count weeks after the first jobs were done
-		if job.RunCount() < len(job.Weekdays()) {
+		weekDays := job.Weekdays()
+		if job.lastRun.Weekday() != weekDays[len(weekDays)-1] {
 			return daysToWeekday
 		}
 		if daysToWeekday > 0 {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2322,9 +2322,9 @@ func TestScheduler_CheckEveryWeekHigherThanOne(t *testing.T) {
 		daysToTest  []int
 		caseTest    int
 	}{
-		{description: "every two weeks after run the first scheduled task", interval: 2, weekDays: []time.Weekday{time.Thursday}, daysToTest: []int{1, 2}, caseTest: 1},
-		{description: "every three weeks after run the first scheduled task", interval: 3, weekDays: []time.Weekday{time.Thursday}, daysToTest: []int{1, 2}, caseTest: 2},
-		{description: "every two weeks after run the first 2 scheduled tasks", interval: 2, weekDays: []time.Weekday{time.Thursday, time.Friday}, daysToTest: []int{1, 2, 3}, caseTest: 3},
+		{description: "every two weeks after run the first scheduled task", interval: 2, weekDays: []time.Weekday{time.Thursday}, daysToTest: []int{1, 2, 15, 16}, caseTest: 1},
+		{description: "every three weeks after run the first scheduled task", interval: 3, weekDays: []time.Weekday{time.Thursday}, daysToTest: []int{1, 2, 15, 16}, caseTest: 2},
+		{description: "every two weeks after run the first 2 scheduled tasks", interval: 2, weekDays: []time.Weekday{time.Friday, time.Thursday}, daysToTest: []int{1, 2, 3, 15, 16, 17}, caseTest: 3},
 	}
 
 	const (
@@ -2347,13 +2347,14 @@ func TestScheduler_CheckEveryWeekHigherThanOne(t *testing.T) {
 			}
 			job, err := s.Do(func() {})
 			require.NoError(t, err)
-			for numJob, day := range tc.daysToTest {
+			for _, day := range tc.daysToTest {
 				lastRun := januaryDay2020At(day)
 
 				job.lastRun = lastRun
 				got := s.durationToNextRun(lastRun, job).duration
 
-				if numJob < len(tc.weekDays) {
+				jobWeekdays := job.Weekdays()
+				if lastRun.Weekday() < jobWeekdays[len(jobWeekdays)-1] {
 					assert.Equal(t, wantTimeUntilNextRunOneDay, got)
 				} else {
 					if tc.caseTest == 1 {


### PR DESCRIPTION
### What does this do?

the root cause of this issue is wrong logic. it should use the weekday to calculate instead of a job.RunCount.
if job.RunCount run over the setting days and it'll encounter an error

### Which issue(s) does this PR fix/relate to?
fix #590 <br/>

### List any changes that modify/break current functionality
only fix bugs for schedule. if it executes though all weekdays one time, the behavior will change. <br>
ex: user sets. `.Every(2).Weeks().Monday().Tuesday().At("10:00")`.  then after executing Monday and Tuesday, the bug will show up. In the next round, after executing on Monday it will wait 2 weeks for execution on Tuesday

### Have you included tests for your changes?
yes, adjusted existing testing

### Did you document any new/modified functionality?
n/a

### Notes
