### PR TITLE
Avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/gocron.go
+++ b/gocron.go
@@ -136,9 +136,9 @@ func getFunctionNameOfPointer(fn interface{}) string {
 func parseTime(t string) (hour, min, sec int, err error) {
 	var timeLayout string
 	switch {
-	case timeWithSeconds.Match([]byte(t)):
+	case timeWithSeconds.MatchString(t):
 		timeLayout = "15:04:05"
-	case timeWithoutSeconds.Match([]byte(t)):
+	case timeWithoutSeconds.MatchString(t):
 		timeLayout = "15:04"
 	default:
 		return 0, 0, 0, ErrUnsupportedTimeFormat


### PR DESCRIPTION
### What does this do?

We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance improvement.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := timeWithSeconds.Match([]byte("06:18:01")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := timeWithSeconds.MatchString("06:18:01"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/go-co-op/gocron
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 7213512	       223.8 ns/op	       8 B/op	       1 allocs/op
BenchmarkMatchString-16    	 8484169	       145.8 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/go-co-op/gocron	4.114s
```


### Which issue(s) does this PR fix/relate to?


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
