### PR TITLE
fix(scheduler): ensure negative intervals given to `Every` return an immediate error #600

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -537,6 +537,7 @@ func (s *Scheduler) EveryRandom(lower, upper int) *Scheduler {
 // Every schedules a new periodic Job with an interval.
 // Interval can be an int, time.Duration or a string that
 // parses with time.ParseDuration().
+// Negative intervals will return an error.
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 //
 // The job is run immediately, unless:

--- a/scheduler.go
+++ b/scheduler.go
@@ -553,6 +553,9 @@ func (s *Scheduler) Every(interval interface{}) *Scheduler {
 			job.error = wrapOrError(job.error, ErrInvalidInterval)
 		}
 	case time.Duration:
+		if interval <= 0 {
+			job.error = wrapOrError(job.error, ErrInvalidInterval)
+		}
 		job.setInterval(0)
 		job.setDuration(interval)
 		job.setUnit(duration)
@@ -560,6 +563,9 @@ func (s *Scheduler) Every(interval interface{}) *Scheduler {
 		d, err := time.ParseDuration(interval)
 		if err != nil {
 			job.error = wrapOrError(job.error, err)
+		}
+		if d <= 0 {
+			job.error = wrapOrError(job.error, ErrInvalidInterval)
 		}
 		job.setDuration(d)
 		job.setUnit(duration)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -145,6 +145,12 @@ func TestScheduler_Every(t *testing.T) {
 		}
 		s.Stop()
 		assert.Equal(t, 6, counter)
+
+		_, err = s.Every(-1 * time.Millisecond).Do(func() {
+			// do nothing
+		})
+
+		require.EqualError(t, err, ErrInvalidInterval)
 	})
 
 	t.Run("int", func(t *testing.T) {
@@ -192,6 +198,12 @@ func TestScheduler_Every(t *testing.T) {
 		}
 		s.Stop()
 		assert.Equal(t, 2, counter)
+
+		_, err = s.Every("-1ms").Do(func() {
+			// do nothing
+		})
+
+		require.EqualError(t, err, ErrInvalidInterval)
 	})
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -150,7 +150,7 @@ func TestScheduler_Every(t *testing.T) {
 			// do nothing
 		})
 
-		require.EqualError(t, err, ErrInvalidInterval.Error())
+		require.ErrorIs(t, err, ErrInvalidInterval)
 	})
 
 	t.Run("int", func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestScheduler_Every(t *testing.T) {
 			// do nothing
 		})
 
-		require.EqualError(t, err, ErrInvalidInterval.Error())
+		require.ErrorIs(t, err, ErrInvalidInterval)
 	})
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -150,7 +150,7 @@ func TestScheduler_Every(t *testing.T) {
 			// do nothing
 		})
 
-		require.ErrorIs(t, err, ErrInvalidInterval)
+		require.Contains(t, err.Error(), ErrInvalidInterval.Error())
 	})
 
 	t.Run("int", func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestScheduler_Every(t *testing.T) {
 			// do nothing
 		})
 
-		require.ErrorIs(t, err, ErrInvalidInterval)
+		require.Contains(t, err.Error(), ErrInvalidInterval.Error())
 	})
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -82,8 +82,10 @@ func TestScheduler_Every_InvalidInterval(t *testing.T) {
 		interval      interface{}
 		expectedError string
 	}{
-		{"zero", 0, ErrInvalidInterval.Error()},
-		{"negative", -1, ErrInvalidInterval.Error()},
+		{"zero int", 0, ErrInvalidInterval.Error()},
+		{"negative int", -1, ErrInvalidInterval.Error()},
+		{"negative time.Duration", -1 * time.Millisecond, ErrInvalidInterval.Error()},
+		{"negative string duration", "-1ms", ErrInvalidInterval.Error()},
 		{"invalid string duration", "bad", "time: invalid duration \"bad\""},
 	}
 
@@ -93,7 +95,7 @@ func TestScheduler_Every_InvalidInterval(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			_, err := s.Every(tc.interval).Do(func() {})
 			require.Error(t, err)
-			assert.EqualError(t, err, tc.expectedError)
+			assert.ErrorContains(t, err, tc.expectedError)
 		})
 	}
 }
@@ -145,12 +147,6 @@ func TestScheduler_Every(t *testing.T) {
 		}
 		s.Stop()
 		assert.Equal(t, 6, counter)
-
-		_, err = s.Every(-1 * time.Millisecond).Do(func() {
-			// do nothing
-		})
-
-		require.Contains(t, err.Error(), ErrInvalidInterval.Error())
 	})
 
 	t.Run("int", func(t *testing.T) {
@@ -198,12 +194,6 @@ func TestScheduler_Every(t *testing.T) {
 		}
 		s.Stop()
 		assert.Equal(t, 2, counter)
-
-		_, err = s.Every("-1ms").Do(func() {
-			// do nothing
-		})
-
-		require.Contains(t, err.Error(), ErrInvalidInterval.Error())
 	})
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -150,7 +150,7 @@ func TestScheduler_Every(t *testing.T) {
 			// do nothing
 		})
 
-		require.EqualError(t, err, ErrInvalidInterval)
+		require.EqualError(t, err, ErrInvalidInterval.Error())
 	})
 
 	t.Run("int", func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestScheduler_Every(t *testing.T) {
 			// do nothing
 		})
 
-		require.EqualError(t, err, ErrInvalidInterval)
+		require.EqualError(t, err, ErrInvalidInterval.Error())
 	})
 }
 


### PR DESCRIPTION
### What does this do?

Ensures negative intervals return an immediate error.

### Which issue(s) does this PR fix/relate to?
Resolves #600 


### List any changes that modify/break current functionality

Negative intervals will now return an error.

### Have you included tests for your changes?
Yes.

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes

Potentially breaking change for any consumer expecting negative intervals to not return an error.