### PR TITLE
elector test & makefile test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,7 @@ lint:
 
 test:
 	@go test -race -v $(GO_FLAGS) -count=1 $(GO_PKGS)
+
+test_coverage:
+	@go test -race -v $(GO_FLAGS) -count=1 -coverprofile=coverage.out -covermode=atomic $(GO_PKGS)
+	@go tool cover -html coverage.out


### PR DESCRIPTION
### What does this do?
- adds a unit test for the distributed elector that confirms that only one instance of the job is run
- adds a test coverage option to the makefile

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
