### PR TITLE
add job storage

### DIFF
--- a/job.go
+++ b/job.go
@@ -138,13 +138,18 @@ const (
 
 // newJob creates a new Job with the provided interval
 func newJob(interval int, startImmediately bool, singletonMode bool) *Job {
+	return newJobWithUUID(interval, startImmediately, singletonMode, uuid.New())
+}
+
+// newJobWithUUID creates a new Job with the provided interval and uuid
+func newJobWithUUID(interval int, startImmediately bool, singletonMode bool, id uuid.UUID) *Job {
 	ctx, cancel := context.WithCancel(context.Background())
 	job := &Job{
 		mu:       &jobMutex{},
 		interval: interval,
 		unit:     seconds,
 		jobFunction: jobFunction{
-			id: uuid.New(),
+			id: id,
 			jobRunTimes: &jobRunTimes{
 				jobRunTimesMu: &sync.Mutex{},
 				lastRun:       time.Time{},

--- a/storage.go
+++ b/storage.go
@@ -1,0 +1,40 @@
+package gocron
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type JobObject struct {
+	UUID    uuid.UUID
+	JobName string
+	LastRun time.Time
+
+	Cron            string
+	CronWithSeconds bool
+
+	Every interface{}
+
+	Unit    string
+	WeekDay *time.Weekday
+	Months  []int
+
+	At []interface{}
+}
+
+type JobStorage interface {
+	LoadJobs() ([]JobObject, error)
+}
+
+type JobResult struct {
+	UUID       uuid.UUID
+	JobName    string
+	RunTimes   *jobRunTimes
+	ReportTime time.Time
+	Err        error
+}
+
+type JobResultReporter interface {
+	ReportJobResult(JobResult)
+}


### PR DESCRIPTION
### What does this do?
It allows the scheduler to load jobs from a job object, which may come from persistent storage.

And it reports job run results to a reporter interface, which can be helpful for job resuming.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves #533 

### List any changes that modify/break current functionality
No break changes.

### Have you included tests for your changes?
Yes. 

1.  `TestLoadJobFromObject` in `scheduler_test.go`
2. `Test_ExecutorJobReport` in `executor_test.go`

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
