### PR TITLE
correct lock to use job.name instead of id

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -337,7 +337,7 @@ func (e *executor) runJob(j internalJob) {
 			return
 		}
 	} else if e.locker != nil {
-		lock, err := e.locker.Lock(j.ctx, j.id.String())
+		lock, err := e.locker.Lock(j.ctx, j.name)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
### What does this do?


### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves https://github.com/go-co-op/gocron/commit/7fea9871373f57ba9e66edf82fd667ab4443af76#r132704666

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
