### PR TITLE
allow max concurrent runs and singleton mode together

### DIFF
--- a/job.go
+++ b/job.go
@@ -475,10 +475,6 @@ func WithName(name string) JobOption {
 // WithSingletonMode keeps the job from running again if it is already running.
 // This is useful for jobs that should not overlap, and that occasionally
 // (but not consistently) run longer than the interval between job runs.
-//
-// Note - this is mutually exclusive with WithLimitConcurrentJobs. If both
-// are set, WithLimitConcurrentJobs will take precedence.
-// WithSingletonMode effectively sets a per-job limit of 1 concurrent job.
 func WithSingletonMode(mode LimitMode) JobOption {
 	return func(j *internalJob) error {
 		j.singletonMode = true


### PR DESCRIPTION
### What does this do?
allows for singleton mode and max concurrent runs to be combined. The resulting behavior is that if you have a limit of say 2 jobs concurrently, you can't have one job take both those slots. By having singleton enabled on a job, it is prevented from running by two limitModeRunners simultaneously. 

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
#624 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
