### PR TITLE
daily job next logic failed to consider 1 midnight attime

### DIFF
--- a/job_test.go
+++ b/job_test.go
@@ -51,6 +51,16 @@ func TestDailyJob_next(t *testing.T) {
 		expectedDurationToNextRun time.Duration
 	}{
 		{
+			"daily at midnight",
+			1,
+			[]time.Time{
+				time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC),
+			},
+			time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2000, 1, 2, 0, 0, 0, 0, time.UTC),
+			24 * time.Hour,
+		},
+		{
 			"daily multiple at times",
 			1,
 			[]time.Time{


### PR DESCRIPTION
### What does this do?
Fixes the logic in the daily job's next function to handle a single at time that is midnight. The bug was due to the next day being checked also being at midnight and using time.After, vs. also checking for time equality


### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #634 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
