### PR TITLE
fix: check function param length and type

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,8 @@ var (
 	ErrMonthlyJobMinutesSeconds      = fmt.Errorf("gocron: MonthlyJob: atTimes minutes and seconds must be between 0 and 59 inclusive")
 	ErrNewJobTaskNil                 = fmt.Errorf("gocron: NewJob: Task must not be nil")
 	ErrNewJobTaskNotFunc             = fmt.Errorf("gocron: NewJob: Task.Function must be of kind reflect.Func")
+	ErrNewJobWrongNumberOfParameters = fmt.Errorf("gocron: NewJob: Number of provided parameters does not match expected")
+	ErrNewJobWrongTypeOfParameters   = fmt.Errorf("gocron: NewJob: Type of provided parameters does not match expected")
 	ErrStopExecutorTimedOut          = fmt.Errorf("gocron: timed out waiting for executor to stop")
 	ErrStopJobsTimedOut              = fmt.Errorf("gocron: timed out waiting for jobs to finish")
 	ErrStopSchedulerTimedOut         = fmt.Errorf("gocron: timed out waiting for scheduler to stop")

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -748,6 +748,8 @@ func TestScheduler_NewJobTask(t *testing.T) {
 	goleak.VerifyNone(t)
 
 	testFuncPtr := func() {}
+	testFuncWithParams := func(one, two string) {}
+	testStruct := struct{}{}
 
 	tests := []struct {
 		name string
@@ -772,6 +774,66 @@ func TestScheduler_NewJobTask(t *testing.T) {
 		{
 			"task func is pointer",
 			NewTask(&testFuncPtr),
+			nil,
+		},
+		{
+			"parameter number does not match",
+			NewTask(testFuncWithParams, "one"),
+			ErrNewJobWrongNumberOfParameters,
+		},
+		{
+			"parameter type does not match",
+			NewTask(testFuncWithParams, "one", 2),
+			ErrNewJobWrongTypeOfParameters,
+		},
+		{
+			"parameter number does not match - ptr",
+			NewTask(&testFuncWithParams, "one"),
+			ErrNewJobWrongNumberOfParameters,
+		},
+		{
+			"parameter type does not match - ptr",
+			NewTask(&testFuncWithParams, "one", 2),
+			ErrNewJobWrongTypeOfParameters,
+		},
+		{
+			"all good struct",
+			NewTask(func(one struct{}) {}, struct{}{}),
+			nil,
+		},
+		{
+			"all good interface",
+			NewTask(func(one interface{}) {}, struct{}{}),
+			nil,
+		},
+		{
+			"all good any",
+			NewTask(func(one any) {}, struct{}{}),
+			nil,
+		},
+		{
+			"all good slice",
+			NewTask(func(one []struct{}) {}, []struct{}{}),
+			nil,
+		},
+		{
+			"all good chan",
+			NewTask(func(one chan struct{}) {}, make(chan struct{})),
+			nil,
+		},
+		{
+			"all good pointer",
+			NewTask(func(one *struct{}) {}, &testStruct),
+			nil,
+		},
+		{
+			"all good map",
+			NewTask(func(one map[string]struct{}) {}, make(map[string]struct{})),
+			nil,
+		},
+		{
+			"all good",
+			NewTask(&testFuncWithParams, "one", "two"),
 			nil,
 		},
 	}


### PR DESCRIPTION
### What does this do?
Returns an error when a function's arguments and the parameters passed don't match in number or kind

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #637 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
