### PR TITLE
make the order of the returned jobs slice deterministic

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -228,6 +228,17 @@ func (s *scheduler) selectAllJobsOutRequest(out allJobsOutRequest) {
 		outJobs[counter] = s.jobFromInternalJob(j)
 		counter++
 	}
+	slices.SortFunc(outJobs, func(a, b Job) int {
+		aID, bID := a.ID().String(), b.ID().String()
+		switch {
+		case aID < bID:
+			return -1
+		case aID > bID:
+			return 1
+		default:
+			return 0
+		}
+	})
 	select {
 	case <-s.shutdownCtx.Done():
 	case out.outChan <- outJobs:

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1635,3 +1635,32 @@ func TestScheduler_OneTimeJob(t *testing.T) {
 		})
 	}
 }
+
+func TestScheduler_Jobs(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			"order is equal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestScheduler(t)
+
+			for i := 0; i <= 20; i++ {
+				_, err := s.NewJob(
+					DurationJob(time.Second),
+					NewTask(func() {}),
+				)
+				require.NoError(t, err)
+			}
+
+			jobsFirst := s.Jobs()
+			jobsSecond := s.Jobs()
+
+			assert.Equal(t, jobsFirst, jobsSecond)
+		})
+	}
+}


### PR DESCRIPTION
### What does this do?
Because the underlying jobs storage is a map, converting to a slice for return needs to sort to make the results consistent. Otherwise, each call to Jobs will return the jobs in a different order.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #651 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
