### PR TITLE
wait for new job to be fully created before returning

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -367,8 +367,6 @@ func ExampleScheduler_removeByTags() {
 	)
 	fmt.Println(len(s.Jobs()))
 
-	time.Sleep(20 * time.Millisecond)
-
 	s.RemoveByTags("tag1", "tag2")
 
 	fmt.Println(len(s.Jobs()))
@@ -391,7 +389,6 @@ func ExampleScheduler_removeJob() {
 	)
 
 	fmt.Println(len(s.Jobs()))
-	time.Sleep(20 * time.Millisecond)
 
 	_ = s.RemoveJob(j.ID())
 
@@ -664,8 +661,8 @@ func ExampleWithLimitedRuns() {
 	s.Start()
 
 	time.Sleep(100 * time.Millisecond)
-	fmt.Printf("no jobs in scheduler: %v\n", s.Jobs())
 	_ = s.StopJobs()
+	fmt.Printf("no jobs in scheduler: %v\n", s.Jobs())
 	// Output:
 	// one, 2
 	// no jobs in scheduler: []
@@ -748,7 +745,6 @@ func ExampleWithStartAt() {
 		),
 	)
 	s.Start()
-	time.Sleep(20 * time.Millisecond)
 
 	next, _ := j.NextRun()
 	fmt.Println(next)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -301,9 +301,7 @@ func TestScheduler_StopTimeout(t *testing.T) {
 			require.NoError(t, err)
 
 			s.Start()
-			time.Sleep(time.Millisecond * 200)
-			err = s.Shutdown()
-			assert.ErrorIs(t, err, ErrStopJobsTimedOut)
+			assert.ErrorIs(t, err, s.Shutdown())
 			cancel()
 			time.Sleep(2 * time.Second)
 		})
@@ -332,15 +330,11 @@ func TestScheduler_Shutdown(t *testing.T) {
 		require.NoError(t, err)
 
 		s.Start()
-		time.Sleep(50 * time.Millisecond)
 		require.NoError(t, s.StopJobs())
 
-		time.Sleep(200 * time.Millisecond)
 		s.Start()
 
-		time.Sleep(50 * time.Millisecond)
 		require.NoError(t, s.Shutdown())
-		time.Sleep(200 * time.Millisecond)
 	})
 
 	t.Run("calling Job methods after shutdown errors", func(t *testing.T) {
@@ -361,7 +355,6 @@ func TestScheduler_Shutdown(t *testing.T) {
 		require.NoError(t, err)
 
 		s.Start()
-		time.Sleep(50 * time.Millisecond)
 		require.NoError(t, s.Shutdown())
 
 		_, err = j.LastRun()
@@ -465,7 +458,6 @@ func TestScheduler_NewJob(t *testing.T) {
 
 			s.Start()
 			require.NoError(t, s.Shutdown())
-			time.Sleep(50 * time.Millisecond)
 		})
 	}
 }
@@ -1303,7 +1295,6 @@ func TestScheduler_RemoveJob(t *testing.T) {
 				id = uuid.New()
 			}
 
-			time.Sleep(50 * time.Millisecond)
 			err := s.RemoveJob(id)
 			assert.ErrorIs(t, err, err)
 			require.NoError(t, s.Shutdown())


### PR DESCRIPTION
### What does this do?
The new job function was returning prior to fully instantiating the job in the scheduler and this causes a race condition when calling the scheduler for job details.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #656 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
