### PR TITLE
fix unsafe map usage in singletonMode

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -19,7 +19,7 @@ type executor struct {
 	jobOutRequest    chan jobOutRequest
 	stopTimeout      time.Duration
 	done             chan error
-	singletonRunners map[uuid.UUID]singletonRunner
+	singletonRunners sync.Map //map[uuid.UUID]singletonRunner
 	limitMode        *limitModeConfig
 	elector          Elector
 	locker           Locker
@@ -67,7 +67,7 @@ func (e *executor) start() {
 	limitModeJobsWg := &waitGroupWithMutex{}
 
 	// create a fresh map for tracking singleton runners
-	e.singletonRunners = make(map[uuid.UUID]singletonRunner)
+	e.singletonRunners = sync.Map{}
 
 	// start the for leap that is the executor
 	// selecting on channels for work to do
@@ -151,15 +151,18 @@ func (e *executor) start() {
 					if j.singletonMode {
 						// for singleton mode, get the existing runner for the job
 						// or spin up a new one
-						runner, ok := e.singletonRunners[jIn.id]
+						runner := &singletonRunner{}
+						runnerSrc, ok := e.singletonRunners.Load(jIn.id)
 						if !ok {
 							runner.in = make(chan jobIn, 1000)
 							if j.singletonLimitMode == LimitModeReschedule {
 								runner.rescheduleLimiter = make(chan struct{}, 1)
 							}
-							e.singletonRunners[jIn.id] = runner
+							e.singletonRunners.Store(jIn.id, runner)
 							singletonJobsWg.Add(1)
 							go e.singletonModeRunner("singleton-"+jIn.id.String(), runner.in, singletonJobsWg, j.singletonLimitMode, runner.rescheduleLimiter)
+						} else {
+							runner = runnerSrc.(*singletonRunner)
 						}
 
 						if j.singletonLimitMode == LimitModeReschedule {

--- a/executor.go
+++ b/executor.go
@@ -19,7 +19,7 @@ type executor struct {
 	jobOutRequest    chan jobOutRequest
 	stopTimeout      time.Duration
 	done             chan error
-	singletonRunners sync.Map //map[uuid.UUID]singletonRunner
+	singletonRunners *sync.Map // map[uuid.UUID]singletonRunner
 	limitMode        *limitModeConfig
 	elector          Elector
 	locker           Locker
@@ -67,7 +67,7 @@ func (e *executor) start() {
 	limitModeJobsWg := &waitGroupWithMutex{}
 
 	// create a fresh map for tracking singleton runners
-	e.singletonRunners = sync.Map{}
+	e.singletonRunners = &sync.Map{}
 
 	// start the for leap that is the executor
 	// selecting on channels for work to do

--- a/scheduler.go
+++ b/scheduler.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"reflect"
 	"runtime"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -107,7 +106,7 @@ func NewScheduler(options ...SchedulerOption) (Scheduler, error) {
 	exec := executor{
 		stopCh:           make(chan struct{}),
 		stopTimeout:      time.Second * 10,
-		singletonRunners: sync.Map{},
+		singletonRunners: nil,
 		logger:           &noOpLogger{},
 
 		jobsIn:        make(chan jobIn),

--- a/scheduler.go
+++ b/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"reflect"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -106,7 +107,7 @@ func NewScheduler(options ...SchedulerOption) (Scheduler, error) {
 	exec := executor{
 		stopCh:           make(chan struct{}),
 		stopTimeout:      time.Second * 10,
-		singletonRunners: make(map[uuid.UUID]singletonRunner),
+		singletonRunners: sync.Map{},
 		logger:           &noOpLogger{},
 
 		jobsIn:        make(chan jobIn),


### PR DESCRIPTION
### What does this do?
Switches the map used for singleton runners to use sync.Map to prevent unsafe calls from multiple goroutines

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
closes #663 thanks @a3sroot for finding and starting that
resolves #661 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
