### PR TITLE
fix RunNow() when calling from a job returned by Jobs()

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -454,10 +454,11 @@ func (s *scheduler) now() time.Time {
 
 func (s *scheduler) jobFromInternalJob(in internalJob) job {
 	return job{
-		id:            in.id,
-		name:          in.name,
-		tags:          slices.Clone(in.tags),
-		jobOutRequest: s.jobOutRequestCh,
+		in.id,
+		in.name,
+		slices.Clone(in.tags),
+		s.jobOutRequestCh,
+		s.runJobRequestCh,
 	}
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1479,7 +1479,7 @@ func TestScheduler_RunJobNow(t *testing.T) {
 		{
 			"duration job - start immediately",
 			chDurationImmediate,
-			DurationJob(time.Second * 10),
+			DurationJob(time.Second * 5),
 			func() {
 				chDurationImmediate <- struct{}{}
 			},
@@ -1489,7 +1489,7 @@ func TestScheduler_RunJobNow(t *testing.T) {
 				),
 			},
 			func() time.Duration {
-				return 10 * time.Second
+				return 5 * time.Second
 			},
 			2,
 		},
@@ -1529,9 +1529,10 @@ func TestScheduler_RunJobNow(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := newTestScheduler(t)
 
-			j, err := s.NewJob(tt.j, NewTask(tt.fun), tt.opts...)
+			_, err := s.NewJob(tt.j, NewTask(tt.fun), tt.opts...)
 			require.NoError(t, err)
 
+			j := s.Jobs()[0]
 			s.Start()
 
 			var nextRunBefore time.Time
@@ -1567,6 +1568,7 @@ func TestScheduler_RunJobNow(t *testing.T) {
 			nextRunAfter, err := j.NextRun()
 			if tt.expectedDiff != nil && tt.expectedDiff() > 0 {
 				for ; nextRunBefore.IsZero() || nextRunAfter.Equal(nextRunBefore); nextRunAfter, err = j.NextRun() { //nolint:revive
+					time.Sleep(100 * time.Millisecond)
 				}
 			}
 


### PR DESCRIPTION
### What does this do?
Jobs() needs to return the run now channel in order to enable jobs to use RunNow

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #667 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
