### PR TITLE
fix cases where default on send out is resulting in job not going out

### DIFF
--- a/job.go
+++ b/job.go
@@ -846,7 +846,9 @@ type Job interface {
 	NextRun() (time.Time, error)
 	// RunNow runs the job once, now. This does not alter
 	// the existing run schedule, and will respect all job
-	// and scheduler limits.
+	// and scheduler limits. This means that running a job now may
+	// cause the job's regular interval to be rescheduled due to
+	// the instance being run by RunNow blocking your run limit.
 	RunNow() error
 	// Tags returns the job's string tags.
 	Tags() []string

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -1508,7 +1507,7 @@ func TestScheduler_RunJobNow(t *testing.T) {
 				WithSingletonMode(LimitModeReschedule),
 			},
 			func() time.Duration {
-				return 10 * time.Second
+				return 20 * time.Second
 			},
 			1,
 		},


### PR DESCRIPTION
### What does this do?
Had some generally racey behavior in channel sends with a default statement. This was causing certain cases to miss having the job sent out and thus not rescheduled due to the scheduler channel being blocked at the moment the send was attempted.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #683 
resolves #676 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
