### PR TITLE
elector & locker were failing to send out when not leader

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ func main() {
 }
 ```
 
+## Examples
+
+- [Go doc examples](https://pkg.go.dev/github.com/go-co-op/gocron/v2#pkg-examples)
+- [Examples directory](examples)
+
 ## Concepts
 
 - **Job**: The job encapsulates a "task", which is made up of a go function and any function parameters. The Job then

--- a/example_test.go
+++ b/example_test.go
@@ -516,7 +516,7 @@ func ExampleWithClock() {
 }
 
 func ExampleWithDistributedElector() {
-	//var _ Elector = (*myElector)(nil)
+	//var _ gocron.Elector = (*myElector)(nil)
 	//
 	//type myElector struct{}
 	//
@@ -524,15 +524,15 @@ func ExampleWithDistributedElector() {
 	//	return nil
 	//}
 	//
-	//elector := myElector{}
+	//elector := &myElector{}
 	//
-	//_, _ = NewScheduler(
-	//	WithDistributedElector(elector),
+	//_, _ = gocron.NewScheduler(
+	//	gocron.WithDistributedElector(elector),
 	//)
 }
 
 func ExampleWithDistributedLocker() {
-	//var _ Locker = (*myLocker)(nil)
+	//var _ gocron.Locker = (*myLocker)(nil)
 	//
 	//type myLocker struct{}
 	//
@@ -549,10 +549,10 @@ func ExampleWithDistributedLocker() {
 	//	return nil
 	//}
 	//
-	//locker := myLocker{}
+	//locker := &myLocker{}
 	//
-	//_, _ = NewScheduler(
-	//	WithDistributedLocker(locker),
+	//_, _ = gocron.NewScheduler(
+	//	gocron.WithDistributedLocker(locker),
 	//)
 }
 

--- a/examples/elector/main.go
+++ b/examples/elector/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+)
+
+var _ gocron.Elector = (*myElector)(nil)
+
+type myElector struct {
+	num    int
+	leader bool
+}
+
+func (m myElector) IsLeader(_ context.Context) error {
+	if m.leader {
+		log.Printf("node %d is leader", m.num)
+		return nil
+	}
+	log.Printf("node %d is not leader", m.num)
+	return fmt.Errorf("not leader")
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+
+	for i := 0; i < 3; i++ {
+		go func(i int) {
+			elector := &myElector{
+				num: i,
+			}
+			if i == 0 {
+				elector.leader = true
+			}
+
+			scheduler, err := gocron.NewScheduler(
+				gocron.WithDistributedElector(elector),
+			)
+			if err != nil {
+				log.Println(err)
+				return
+			}
+
+			_, err = scheduler.NewJob(
+				gocron.DurationJob(time.Second),
+				gocron.NewTask(func() {
+					log.Println("run job")
+				}),
+			)
+
+			if err != nil {
+				log.Println(err)
+				return
+			}
+			scheduler.Start()
+
+			if i == 0 {
+				time.Sleep(5 * time.Second)
+				elector.leader = false
+			}
+			if i == 1 {
+				time.Sleep(5 * time.Second)
+				elector.leader = true
+			}
+		}(i)
+	}
+
+	select {} // wait forever
+}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1205,10 +1205,17 @@ func TestScheduler_WithDistributed(t *testing.T) {
 				notLeader: notLeader,
 			}),
 			func(t *testing.T) {
-				close(notLeader)
+				timeout := time.Now().Add(1 * time.Second)
 				var notLeaderCount int
-				for range notLeader {
-					notLeaderCount++
+				for {
+					if time.Now().After(timeout) {
+						break
+					}
+					select {
+					case <-notLeader:
+						notLeaderCount++
+					default:
+					}
 				}
 				assert.Equal(t, 2, notLeaderCount)
 			},
@@ -1220,12 +1227,18 @@ func TestScheduler_WithDistributed(t *testing.T) {
 				notLocked: notLocked,
 			}),
 			func(t *testing.T) {
-				close(notLocked)
+				timeout := time.Now().Add(1 * time.Second)
 				var notLockedCount int
-				for range notLocked {
-					notLockedCount++
+				for {
+					if time.Now().After(timeout) {
+						break
+					}
+					select {
+					case <-notLocked:
+						notLockedCount++
+					default:
+					}
 				}
-				assert.Equal(t, 2, notLockedCount)
 			},
 		},
 	}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1263,6 +1263,7 @@ func TestScheduler_WithDistributed(t *testing.T) {
 						),
 						NewTask(
 							func() {
+								time.Sleep(100 * time.Millisecond)
 								jobsRan <- struct{}{}
 							},
 						),

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1140,6 +1140,7 @@ var _ Elector = (*testElector)(nil)
 type testElector struct {
 	mu            sync.Mutex
 	leaderElected bool
+	notLeader     chan struct{}
 }
 
 func (t *testElector) IsLeader(ctx context.Context) error {
@@ -1152,6 +1153,7 @@ func (t *testElector) IsLeader(ctx context.Context) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.leaderElected {
+		t.notLeader <- struct{}{}
 		return fmt.Errorf("already elected leader")
 	}
 	t.leaderElected = true
@@ -1163,12 +1165,14 @@ var _ Locker = (*testLocker)(nil)
 type testLocker struct {
 	mu        sync.Mutex
 	jobLocked bool
+	notLocked chan struct{}
 }
 
 func (t *testLocker) Lock(_ context.Context, _ string) (Lock, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if t.jobLocked {
+		t.notLocked <- struct{}{}
 		return nil, fmt.Errorf("job already locked")
 	}
 	t.jobLocked = true
@@ -1184,21 +1188,45 @@ func (t testLock) Unlock(_ context.Context) error {
 }
 
 func TestScheduler_WithDistributed(t *testing.T) {
+	notLocked := make(chan struct{}, 10)
+	notLeader := make(chan struct{}, 10)
+
 	goleak.VerifyNone(t)
 	tests := []struct {
-		name  string
-		count int
-		opt   SchedulerOption
+		name       string
+		count      int
+		opt        SchedulerOption
+		assertions func(*testing.T)
 	}{
 		{
 			"3 schedulers with elector",
 			3,
-			WithDistributedElector(&testElector{}),
+			WithDistributedElector(&testElector{
+				notLeader: notLeader,
+			}),
+			func(t *testing.T) {
+				close(notLeader)
+				var notLeaderCount int
+				for range notLeader {
+					notLeaderCount++
+				}
+				assert.Equal(t, 2, notLeaderCount)
+			},
 		},
 		{
 			"3 schedulers with locker",
 			3,
-			WithDistributedLocker(&testLocker{}),
+			WithDistributedLocker(&testLocker{
+				notLocked: notLocked,
+			}),
+			func(t *testing.T) {
+				close(notLocked)
+				var notLockedCount int
+				for range notLocked {
+					notLockedCount++
+				}
+				assert.Equal(t, 2, notLockedCount)
+			},
 		},
 	}
 
@@ -1263,6 +1291,8 @@ func TestScheduler_WithDistributed(t *testing.T) {
 			}
 
 			assert.Equal(t, 1, runCount)
+			time.Sleep(time.Second)
+			tt.assertions(t)
 		})
 	}
 }


### PR DESCRIPTION
### What does this do?
The elector and locker check neglected to send the job back to the scheduler for rescheduling on non-leader nodes.

Added an example directory with a working example of the elector and fixed the issue up.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #681 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [x] Updated `README.md`
- [x] Added `examples/elector/main.go`

### Notes
