### PR TITLE
fix case where job removed causes panic when rescheduling

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -288,7 +288,12 @@ func (s *scheduler) selectRemoveJob(id uuid.UUID) {
 // Jobs coming back from the executor to the scheduler that
 // need to evaluated for rescheduling.
 func (s *scheduler) selectExecJobIDsOut(id uuid.UUID) {
-	j := s.jobs[id]
+	j, ok := s.jobs[id]
+	if !ok {
+		// the job was removed while it was running, and
+		// so we don't need to reschedule it.
+		return
+	}
 	j.lastRun = j.nextRun
 
 	// if the job has a limited number of runs set, we need to


### PR DESCRIPTION
### What does this do?
Check the map for the job before trying to reschedule. It may have been removed.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
related to #696 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
