### PR TITLE
add another out channel so we can properly report lastRun

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -346,7 +346,10 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	_ = callJobFuncWithParams(j.beforeJobRuns, j.id, j.name)
 
 	e.sendOutForRescheduling(&jIn)
-	e.jobsOutCompleted <- j.id
+	select {
+	case e.jobsOutCompleted <- j.id:
+	case <-e.ctx.Done():
+	}
 
 	startTime := time.Now()
 	err := callJobFuncWithParams(j.function, j.parameters...)

--- a/job.go
+++ b/job.go
@@ -24,7 +24,9 @@ type internalJob struct {
 	name   string
 	tags   []string
 	jobSchedule
-	lastRun, nextRun   time.Time
+	lastScheduledRun   time.Time
+	nextScheduled      time.Time
+	lastRun            time.Time
 	function           any
 	parameters         []any
 	timer              clockwork.Timer
@@ -678,18 +680,18 @@ func (d dailyJob) next(lastRun time.Time) time.Time {
 
 func (d dailyJob) nextDay(lastRun time.Time, firstPass bool) time.Time {
 	for _, at := range d.atTimes {
-		// sub the at time hour/min/sec onto the lastRun's values
+		// sub the at time hour/min/sec onto the lastScheduledRun's values
 		// to use in checks to see if we've got our next run time
 		atDate := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day(), at.Hour(), at.Minute(), at.Second(), lastRun.Nanosecond(), lastRun.Location())
 
 		if firstPass && atDate.After(lastRun) {
 			// checking to see if it is after i.e. greater than,
-			// and not greater or equal as our lastRun day/time
+			// and not greater or equal as our lastScheduledRun day/time
 			// will be in the loop, and we don't want to select it again
 			return atDate
 		} else if !firstPass && !atDate.Before(lastRun) {
 			// now that we're looking at the next day, it's ok to consider
-			// the same at time that was last run (as lastRun has been incremented)
+			// the same at time that was last run (as lastScheduledRun has been incremented)
 			return atDate
 		}
 	}
@@ -724,18 +726,18 @@ func (w weeklyJob) nextWeekDayAtTime(lastRun time.Time, firstPass bool) time.Tim
 			// weekDayDiff is used to add the correct amount to the atDate day below
 			weekDayDiff := wd - lastRun.Weekday()
 			for _, at := range w.atTimes {
-				// sub the at time hour/min/sec onto the lastRun's values
+				// sub the at time hour/min/sec onto the lastScheduledRun's values
 				// to use in checks to see if we've got our next run time
 				atDate := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day()+int(weekDayDiff), at.Hour(), at.Minute(), at.Second(), lastRun.Nanosecond(), lastRun.Location())
 
 				if firstPass && atDate.After(lastRun) {
 					// checking to see if it is after i.e. greater than,
-					// and not greater or equal as our lastRun day/time
+					// and not greater or equal as our lastScheduledRun day/time
 					// will be in the loop, and we don't want to select it again
 					return atDate
 				} else if !firstPass && !atDate.Before(lastRun) {
 					// now that we're looking at the next week, it's ok to consider
-					// the same at time that was last run (as lastRun has been incremented)
+					// the same at time that was last run (as lastScheduledRun has been incremented)
 					return atDate
 				}
 			}
@@ -792,7 +794,7 @@ func (m monthlyJob) nextMonthDayAtTime(lastRun time.Time, days []int, firstPass 
 	for _, day := range days {
 		if day >= lastRun.Day() {
 			for _, at := range m.atTimes {
-				// sub the day, and the at time hour/min/sec onto the lastRun's values
+				// sub the day, and the at time hour/min/sec onto the lastScheduledRun's values
 				// to use in checks to see if we've got our next run time
 				atDate := time.Date(lastRun.Year(), lastRun.Month(), day, at.Hour(), at.Minute(), at.Second(), lastRun.Nanosecond(), lastRun.Location())
 
@@ -804,12 +806,12 @@ func (m monthlyJob) nextMonthDayAtTime(lastRun time.Time, days []int, firstPass 
 
 				if firstPass && atDate.After(lastRun) {
 					// checking to see if it is after i.e. greater than,
-					// and not greater or equal as our lastRun day/time
+					// and not greater or equal as our lastScheduledRun day/time
 					// will be in the loop, and we don't want to select it again
 					return atDate
 				} else if !firstPass && !atDate.Before(lastRun) {
 					// now that we're looking at the next month, it's ok to consider
-					// the same at time that was  lastRun (as lastRun has been incremented)
+					// the same at time that was  lastScheduledRun (as lastScheduledRun has been incremented)
 					return atDate
 				}
 			}
@@ -889,7 +891,7 @@ func (j job) NextRun() (time.Time, error) {
 	if ij == nil || ij.id == uuid.Nil {
 		return time.Time{}, ErrJobNotFound
 	}
-	return ij.nextRun, nil
+	return ij.nextScheduled, nil
 }
 
 func (j job) Tags() []string {


### PR DESCRIPTION
### What does this do?
With a change in how the lastrun was being reporting to handle rescheduling, we needed to also update how lastRun is being recorded to actually track when the job was run vs. when it was sent back for rescheduling.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #694 
resolves #685 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
DONE Need to update with a test: manual testing confirms:

singleton mode issue
```go
package main

import (
	"fmt"
	"log"
	"time"

	"github.com/go-co-op/gocron/v2"
)

func main() {
	s, _ := gocron.NewScheduler()
	s.Start()

	j, _ := s.NewJob(
		gocron.DurationJob(2*time.Second),
		gocron.NewTask(func() {
			log.Println("job running")
			time.Sleep(3 * time.Second)
			log.Println("job done")
		}),
		gocron.WithSingletonMode(gocron.LimitModeWait),
	)

	for {
		time.Sleep(1 * time.Second)
		lastRun, err := j.LastRun()
		if err != nil {
			fmt.Printf("job lastRun error: %s\n", err)
			continue
		}
		fmt.Printf("job lastRun: %s\n", lastRun)
	}

}
```

RunNow issue
```go
package main

import (
	"fmt"
	"log"
	"time"

	"github.com/go-co-op/gocron/v2"
)

func main() {
	s, _ := gocron.NewScheduler()
	s.Start()

	j, _ := s.NewJob(
		gocron.DurationJob(10*time.Second),
		gocron.NewTask(func() {
			log.Println("job running")
			time.Sleep(3 * time.Second)
			log.Println("job done")
		}),
		gocron.WithSingletonMode(gocron.LimitModeWait),
	)

	for {
		time.Sleep(1 * time.Second)
		lastRun, err := j.LastRun()
		if err != nil {
			fmt.Printf("job lastRun error: %s\n", err)
			continue
		}
		fmt.Printf("job lastRun: %s\n", lastRun)

		log.Println("running job now")
		j.RunNow()
	}

}
```

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
