### PR TITLE
feat: 🎸 duration job time interval zero

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrDailyJobAtTimesNil            = fmt.Errorf("gocron: DailyJob: atTimes must not be nil")
 	ErrDailyJobHours                 = fmt.Errorf("gocron: DailyJob: atTimes hours must be between 0 and 23 inclusive")
 	ErrDailyJobMinutesSeconds        = fmt.Errorf("gocron: DailyJob: atTimes minutes and seconds must be between 0 and 59 inclusive")
+	ErrDurationJobIntervalZero       = fmt.Errorf("gocron: DurationJob: time interval is 0")
 	ErrDurationRandomJobMinMax       = fmt.Errorf("gocron: DurationRandomJob: minimum duration must be less than maximum duration")
 	ErrEventListenerFuncNil          = fmt.Errorf("gocron: eventListenerFunc must not be nil")
 	ErrJobNotFound                   = fmt.Errorf("gocron: job not found")

--- a/job.go
+++ b/job.go
@@ -148,6 +148,9 @@ type durationJobDefinition struct {
 }
 
 func (d durationJobDefinition) setup(j *internalJob, _ *time.Location) error {
+	if d.duration == 0 {
+		return ErrDurationJobIntervalZero
+	}
 	j.jobSchedule = &durationJob{duration: d.duration}
 	return nil
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -479,6 +479,12 @@ func TestScheduler_NewJobErrors(t *testing.T) {
 			ErrCronJobParse,
 		},
 		{
+			"duration job time interval is zero",
+			DurationJob(0 * time.Second),
+			nil,
+			ErrDurationJobIntervalZero,
+		},
+		{
 			"random with bad min/max",
 			DurationRandomJob(
 				time.Second*5,


### PR DESCRIPTION
### What does this do?

sometimes across grpc call or method call, will be input a zero interval, it can be occour a error. so I modify some code to add occor error.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?

yes

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
