### PR TITLE
fix nextRun with singleton mode reporting incorrect time

### DIFF
--- a/job.go
+++ b/job.go
@@ -24,8 +24,12 @@ type internalJob struct {
 	name   string
 	tags   []string
 	jobSchedule
-	lastScheduledRun   time.Time
-	nextScheduled      time.Time
+	lastScheduledRun time.Time
+
+	// as some jobs may queue up, it's possible to
+	// have multiple nextScheduled times
+	nextScheduled []time.Time
+
 	lastRun            time.Time
 	function           any
 	parameters         []any
@@ -894,7 +898,12 @@ func (j job) NextRun() (time.Time, error) {
 	if ij == nil || ij.id == uuid.Nil {
 		return time.Time{}, ErrJobNotFound
 	}
-	return ij.nextScheduled, nil
+	if len(ij.nextScheduled) == 0 {
+		return time.Time{}, nil
+	}
+	// the first element is the next scheduled run with subsequent
+	// runs following after in the slice
+	return ij.nextScheduled[0], nil
 }
 
 func (j job) Tags() []string {

--- a/job.go
+++ b/job.go
@@ -24,7 +24,6 @@ type internalJob struct {
 	name   string
 	tags   []string
 	jobSchedule
-	lastScheduledRun time.Time
 
 	// as some jobs may queue up, it's possible to
 	// have multiple nextScheduled times

--- a/job_test.go
+++ b/job_test.go
@@ -492,3 +492,42 @@ func TestWithEventListeners(t *testing.T) {
 		})
 	}
 }
+
+func TestJob_NextRun(t *testing.T) {
+	testTime := time.Now()
+
+	s := newTestScheduler(t)
+
+	// run a job every 10 milliseconds that starts 10 milliseconds after the current time
+	j, err := s.NewJob(
+		DurationJob(
+			10*time.Millisecond,
+		),
+		NewTask(
+			func() {},
+		),
+		WithStartAt(WithStartDateTime(testTime.Add(10*time.Millisecond))),
+		WithSingletonMode(LimitModeReschedule),
+	)
+	require.NoError(t, err)
+
+	s.Start()
+	nextRun, err := j.NextRun()
+	require.NoError(t, err)
+
+	// `NextRun` should report `testTime.Add(10*time.Millisecond)`
+	assert.Equal(t, testTime.Add(10*time.Millisecond), nextRun)
+
+	// sleep for 11ms to wait for the next job
+	time.Sleep(11 * time.Millisecond)
+
+	nextRun, err = j.NextRun()
+	assert.NoError(t, err)
+
+	// `NextRun` should report a time 20 milliseconds after `testTime`, but instead reports a value that is `30ms` after
+	assert.Equal(t, testTime.Add(20*time.Millisecond), nextRun)
+	assert.Equal(t, 20*time.Millisecond, nextRun.Sub(testTime))
+
+	err = s.Shutdown()
+	require.NoError(t, err)
+}

--- a/job_test.go
+++ b/job_test.go
@@ -494,37 +494,57 @@ func TestWithEventListeners(t *testing.T) {
 }
 
 func TestJob_NextRun(t *testing.T) {
-	testTime := time.Now()
-
-	s := newTestScheduler(t)
-
-	// run a job every 10 milliseconds that starts 10 milliseconds after the current time
-	j, err := s.NewJob(
-		DurationJob(
-			100*time.Millisecond,
-		),
-		NewTask(
+	tests := []struct {
+		name string
+		f    func()
+	}{
+		{
+			"simple",
 			func() {},
-		),
-		WithStartAt(WithStartDateTime(testTime.Add(100*time.Millisecond))),
-		WithSingletonMode(LimitModeReschedule),
-	)
-	require.NoError(t, err)
+		},
+		{
+			"sleep 3 seconds",
+			func() {
+				time.Sleep(300 * time.Millisecond)
+			},
+		},
+	}
 
-	s.Start()
-	nextRun, err := j.NextRun()
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testTime := time.Now()
 
-	assert.Equal(t, testTime.Add(100*time.Millisecond), nextRun)
+			s := newTestScheduler(t)
 
-	time.Sleep(150 * time.Millisecond)
+			// run a job every 10 milliseconds that starts 10 milliseconds after the current time
+			j, err := s.NewJob(
+				DurationJob(
+					100*time.Millisecond,
+				),
+				NewTask(
+					func() {},
+				),
+				WithStartAt(WithStartDateTime(testTime.Add(100*time.Millisecond))),
+				WithSingletonMode(LimitModeReschedule),
+			)
+			require.NoError(t, err)
 
-	nextRun, err = j.NextRun()
-	assert.NoError(t, err)
+			s.Start()
+			nextRun, err := j.NextRun()
+			require.NoError(t, err)
 
-	assert.Equal(t, testTime.Add(200*time.Millisecond), nextRun)
-	assert.Equal(t, 200*time.Millisecond, nextRun.Sub(testTime))
+			assert.Equal(t, testTime.Add(100*time.Millisecond), nextRun)
 
-	err = s.Shutdown()
-	require.NoError(t, err)
+			time.Sleep(150 * time.Millisecond)
+
+			nextRun, err = j.NextRun()
+			assert.NoError(t, err)
+
+			assert.Equal(t, testTime.Add(200*time.Millisecond), nextRun)
+			assert.Equal(t, 200*time.Millisecond, nextRun.Sub(testTime))
+
+			err = s.Shutdown()
+			require.NoError(t, err)
+		})
+	}
 }

--- a/job_test.go
+++ b/job_test.go
@@ -501,12 +501,12 @@ func TestJob_NextRun(t *testing.T) {
 	// run a job every 10 milliseconds that starts 10 milliseconds after the current time
 	j, err := s.NewJob(
 		DurationJob(
-			10*time.Millisecond,
+			100*time.Millisecond,
 		),
 		NewTask(
 			func() {},
 		),
-		WithStartAt(WithStartDateTime(testTime.Add(10*time.Millisecond))),
+		WithStartAt(WithStartDateTime(testTime.Add(100*time.Millisecond))),
 		WithSingletonMode(LimitModeReschedule),
 	)
 	require.NoError(t, err)
@@ -515,18 +515,15 @@ func TestJob_NextRun(t *testing.T) {
 	nextRun, err := j.NextRun()
 	require.NoError(t, err)
 
-	// `NextRun` should report `testTime.Add(10*time.Millisecond)`
-	assert.Equal(t, testTime.Add(10*time.Millisecond), nextRun)
+	assert.Equal(t, testTime.Add(100*time.Millisecond), nextRun)
 
-	// sleep for 11ms to wait for the next job
-	time.Sleep(11 * time.Millisecond)
+	time.Sleep(150 * time.Millisecond)
 
 	nextRun, err = j.NextRun()
 	assert.NoError(t, err)
 
-	// `NextRun` should report a time 20 milliseconds after `testTime`, but instead reports a value that is `30ms` after
-	assert.Equal(t, testTime.Add(20*time.Millisecond), nextRun)
-	assert.Equal(t, 20*time.Millisecond, nextRun.Sub(testTime))
+	assert.Equal(t, testTime.Add(200*time.Millisecond), nextRun)
+	assert.Equal(t, 200*time.Millisecond, nextRun.Sub(testTime))
 
 	err = s.Shutdown()
 	require.NoError(t, err)

--- a/scheduler.go
+++ b/scheduler.go
@@ -298,6 +298,7 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		// so we don't need to reschedule it.
 		return
 	}
+	var scheduleFrom time.Time
 	if len(j.nextScheduled) > 0 {
 		// always grab the last element in the slice as that is the furthest
 		// out in the future and the time from which we want to calculate
@@ -305,10 +306,10 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		slices.SortStableFunc(j.nextScheduled, func(a, b time.Time) int {
 			return a.Compare(b)
 		})
-		j.lastScheduledRun = j.nextScheduled[len(j.nextScheduled)-1]
+		scheduleFrom = j.nextScheduled[len(j.nextScheduled)-1]
 	}
 
-	next := j.next(j.lastScheduledRun)
+	next := j.next(scheduleFrom)
 	if next.IsZero() {
 		// the job's next function will return zero for OneTime jobs.
 		// since they are one time only, they do not need rescheduling.

--- a/scheduler.go
+++ b/scheduler.go
@@ -302,6 +302,9 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		// always grab the last element in the slice as that is the furthest
 		// out in the future and the time from which we want to calculate
 		// the subsequent next run time.
+		slices.SortStableFunc(j.nextScheduled, func(a, b time.Time) int {
+			return a.Compare(b)
+		})
 		j.lastScheduledRun = j.nextScheduled[len(j.nextScheduled)-1]
 	}
 
@@ -345,14 +348,18 @@ func (s *scheduler) selectExecJobsOutCompleted(id uuid.UUID) {
 		return
 	}
 
-	var newNextScheduled []time.Time
-	for _, t := range j.nextScheduled {
-		if t.Before(s.now()) {
-			continue
+	// if the job has more than one nextScheduled time,
+	// we need to remove any that are in the past.
+	if len(j.nextScheduled) > 1 {
+		var newNextScheduled []time.Time
+		for _, t := range j.nextScheduled {
+			if t.Before(s.now()) {
+				continue
+			}
+			newNextScheduled = append(newNextScheduled, t)
 		}
-		newNextScheduled = append(newNextScheduled, t)
+		j.nextScheduled = newNextScheduled
 	}
-	j.nextScheduled = newNextScheduled
 
 	// if the job has a limited number of runs set, we need to
 	// check how many runs have occurred and stop running this

--- a/scheduler.go
+++ b/scheduler.go
@@ -298,7 +298,12 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		// so we don't need to reschedule it.
 		return
 	}
-	j.lastScheduledRun = j.nextScheduled
+	if len(j.nextScheduled) > 0 {
+		// always grab the last element in the slice as that is the furthest
+		// out in the future and the time from which we want to calculate
+		// the subsequent next run time.
+		j.lastScheduledRun = j.nextScheduled[len(j.nextScheduled)-1]
+	}
 
 	next := j.next(j.lastScheduledRun)
 	if next.IsZero() {
@@ -316,7 +321,7 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 			next = j.next(next)
 		}
 	}
-	j.nextScheduled = next
+	j.nextScheduled = append(j.nextScheduled, next)
 	j.timer = s.clock.AfterFunc(next.Sub(s.now()), func() {
 		// set the actual timer on the job here and listen for
 		// shut down events so that the job doesn't attempt to
@@ -339,6 +344,15 @@ func (s *scheduler) selectExecJobsOutCompleted(id uuid.UUID) {
 	if !ok {
 		return
 	}
+
+	var newNextScheduled []time.Time
+	for _, t := range j.nextScheduled {
+		if t.Before(s.now()) {
+			continue
+		}
+		newNextScheduled = append(newNextScheduled, t)
+	}
+	j.nextScheduled = newNextScheduled
 
 	// if the job has a limited number of runs set, we need to
 	// check how many runs have occurred and stop running this
@@ -400,7 +414,7 @@ func (s *scheduler) selectNewJob(in newJobIn) {
 				}
 			})
 		}
-		j.nextScheduled = next
+		j.nextScheduled = append(j.nextScheduled, next)
 	}
 
 	s.jobs[j.id] = j
@@ -451,7 +465,7 @@ func (s *scheduler) selectStart() {
 				}
 			})
 		}
-		j.nextScheduled = next
+		j.nextScheduled = append(j.nextScheduled, next)
 		s.jobs[id] = j
 	}
 	select {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1622,7 +1622,7 @@ func TestScheduler_RunJobNow(t *testing.T) {
 				WithSingletonMode(LimitModeReschedule),
 			},
 			func() time.Duration {
-				return 20 * time.Second
+				return 10 * time.Second
 			},
 			1,
 		},


### PR DESCRIPTION
### What does this do?
adjusts how the nextScheduledRun field is tracked. Rather than being a single time.Time field it is now a slice of time.Time. This allows for the case, that will often happen with limited/singleton jobs that may be queued up. In this case, there are multiple nextScheduledRun values.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #704 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
yes - thank you @aneesh1 for the excellent ticket write up and test case

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
