### PR TITLE
Add Go 1.22 to test matrix

### DIFF
--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -14,6 +14,7 @@ jobs:
         go-version:
           - "1.20"
           - "1.21"
+          - "1.22"
     name: lint and test
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### What does this do?

Go 1.22 is added to the test matrix


### Which issue(s) does this PR fix/relate to?

#713
