### PR TITLE
don't trash the incoming slice, match what was done in NewAtTime

### DIFF
--- a/job.go
+++ b/job.go
@@ -291,7 +291,8 @@ type Weekdays func() []time.Weekday
 // NewWeekdays provide the days of the week the job should run.
 func NewWeekdays(weekday time.Weekday, weekdays ...time.Weekday) Weekdays {
 	return func() []time.Weekday {
-		return append(weekdays, weekday)
+		weekdays = append(weekdays, weekday)
+		return weekdays
 	}
 }
 


### PR DESCRIPTION
### What does this do?
NewWeekdays can trash the incoming slice, this fixes that

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality
none

### Have you included tests for your changes?
no, existing tests passed
21:25:07 DEBUG: gocron: singleton jobs completed
2024/05/01 21:25:07 DEBUG: gocron: waiting for limit mode jobs to complete
2024/05/01 21:25:07 DEBUG: gocron: limitMode jobs completed
2024/05/01 21:25:07 DEBUG: gocron: executor stopped
2024/05/01 21:25:07 DEBUG: gocron: scheduler stopped
PASS
ok  	github.com/go-co-op/gocron/v2	41.431s


### Did you document any new/modified functionality?
no

- [ not needed] Updated `example_test.go`
- [ not needed] Updated `README.md`

### Notes
