### PR TITLE
after job listener

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -343,6 +343,7 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	} else if j.locker != nil {
 		lock, err := j.locker.Lock(j.ctx, j.name)
 		if err != nil {
+			_ = callJobFuncWithParams(j.afterLockError, j.id, j.name, err)
 			e.sendOutForRescheduling(&jIn)
 			e.incrementJobCounter(j, Skip)
 			return
@@ -351,6 +352,7 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	} else if e.locker != nil {
 		lock, err := e.locker.Lock(j.ctx, j.name)
 		if err != nil {
+			_ = callJobFuncWithParams(j.afterLockError, j.id, j.name, err)
 			e.sendOutForRescheduling(&jIn)
 			e.incrementJobCounter(j, Skip)
 			return

--- a/job.go
+++ b/job.go
@@ -42,6 +42,7 @@ type internalJob struct {
 	afterJobRuns          func(jobID uuid.UUID, jobName string)
 	beforeJobRuns         func(jobID uuid.UUID, jobName string)
 	afterJobRunsWithError func(jobID uuid.UUID, jobName string, err error)
+	afterLockError        func(jobID uuid.UUID, jobName string, err error)
 
 	locker Locker
 }
@@ -635,6 +636,18 @@ func BeforeJobRuns(eventListenerFunc func(jobID uuid.UUID, jobName string)) Even
 			return ErrEventListenerFuncNil
 		}
 		j.beforeJobRuns = eventListenerFunc
+		return nil
+	}
+}
+
+// AfterLockError is used to when the distributed locker returns an error and
+// then run the provided function.
+func AfterLockError(eventListenerFunc func(jobID uuid.UUID, jobName string, err error)) EventListener {
+	return func(j *internalJob) error {
+		if eventListenerFunc == nil {
+			return ErrEventListenerFuncNil
+		}
+		j.afterLockError = eventListenerFunc
 		return nil
 	}
 }

--- a/job_test.go
+++ b/job_test.go
@@ -438,11 +438,19 @@ func TestWithEventListeners(t *testing.T) {
 			nil,
 		},
 		{
+			"afterLockError",
+			[]EventListener{
+				AfterLockError(func(_ uuid.UUID, _ string, err error) {}),
+			},
+			nil,
+		},
+		{
 			"multiple event listeners",
 			[]EventListener{
 				AfterJobRuns(func(_ uuid.UUID, _ string) {}),
 				AfterJobRunsWithError(func(_ uuid.UUID, _ string, _ error) {}),
 				BeforeJobRuns(func(_ uuid.UUID, _ string) {}),
+				AfterLockError(func(_ uuid.UUID, _ string, _ error) {}),
 			},
 			nil,
 		},
@@ -486,6 +494,9 @@ func TestWithEventListeners(t *testing.T) {
 				count++
 			}
 			if ij.beforeJobRuns != nil {
+				count++
+			}
+			if ij.afterLockError != nil {
 				count++
 			}
 			assert.Equal(t, len(tt.eventListeners), count)

--- a/job_test.go
+++ b/job_test.go
@@ -440,7 +440,7 @@ func TestWithEventListeners(t *testing.T) {
 		{
 			"afterLockError",
 			[]EventListener{
-				AfterLockError(func(_ uuid.UUID, _ string, err error) {}),
+				AfterLockError(func(_ uuid.UUID, _ string, _ error) {}),
 			},
 			nil,
 		},

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2,6 +2,7 @@ package gocron
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -47,6 +48,15 @@ func newTestScheduler(t *testing.T, options ...SchedulerOption) Scheduler {
 	s, err := NewScheduler(out...)
 	require.NoError(t, err)
 	return s
+}
+
+var _ Locker = new(errorLocker)
+
+type errorLocker struct {
+}
+
+func (e errorLocker) Lock(_ context.Context, _ string) (Lock, error) {
+	return nil, errors.New("locked")
 }
 
 func TestScheduler_OneSecond_NoOptions(t *testing.T) {
@@ -1605,6 +1615,66 @@ func TestScheduler_WithEventListeners(t *testing.T) {
 				WithStartAt(
 					WithStartImmediately(),
 				),
+				WithEventListeners(tt.el),
+				WithLimitedRuns(1),
+			)
+			require.NoError(t, err)
+
+			s.Start()
+			if tt.expectRun {
+				select {
+				case err = <-listenerRunCh:
+					assert.ErrorIs(t, err, tt.expectErr)
+				case <-time.After(time.Second):
+					t.Fatal("timed out waiting for listener to run")
+				}
+			} else {
+				select {
+				case <-listenerRunCh:
+					t.Fatal("listener ran when it shouldn't have")
+				case <-time.After(time.Millisecond * 100):
+				}
+			}
+
+			require.NoError(t, s.Shutdown())
+		})
+	}
+}
+
+func TestScheduler_WithLocker_WithEventListeners(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	listenerRunCh := make(chan error, 1)
+	tests := []struct {
+		name      string
+		locker    Locker
+		tsk       Task
+		el        EventListener
+		expectRun bool
+		expectErr error
+	}{
+		{
+			"AfterLockError",
+			errorLocker{},
+			NewTask(func() {}),
+			AfterLockError(func(_ uuid.UUID, _ string, err error) {
+				listenerRunCh <- nil
+			}),
+			true,
+			nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newTestScheduler(t)
+			_, err := s.NewJob(
+				DurationJob(time.Minute*10),
+				tt.tsk,
+				WithStartAt(
+					WithStartImmediately(),
+				),
+				WithDistributedJobLocker(tt.locker),
 				WithEventListeners(tt.el),
 				WithLimitedRuns(1),
 			)

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -52,8 +52,7 @@ func newTestScheduler(t *testing.T, options ...SchedulerOption) Scheduler {
 
 var _ Locker = new(errorLocker)
 
-type errorLocker struct {
-}
+type errorLocker struct{}
 
 func (e errorLocker) Lock(_ context.Context, _ string) (Lock, error) {
 	return nil, errors.New("locked")


### PR DESCRIPTION
### What does this do?

Adding an after locker error listener

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
It adds the possibility to react when the locker returns an error.


### List any changes that modify/break current functionality


### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
