### PR TITLE
issue-756: fix interface variadic parameters verifying

### DIFF
--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -926,7 +926,7 @@ func TestScheduler_NewJobTask(t *testing.T) {
 			nil,
 		},
 		{
-			"all good no arguments passed in - interface variadic",
+			"all good - interface variadic, int, string",
 			NewTask(func(args ...interface{}) {}, 1, "2", 3.0),
 			nil,
 		},

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -923,6 +924,16 @@ func TestScheduler_NewJobTask(t *testing.T) {
 			"all good no arguments passed in - variadic",
 			NewTask(func(args ...interface{}) {}),
 			nil,
+		},
+		{
+			"all good no arguments passed in - interface variadic",
+			NewTask(func(args ...interface{}) {}, 1, "2", 3.0),
+			nil,
+		},
+		{
+			"parameter type does not match - different argument types against interface variadic parameters",
+			NewTask(func(args ...io.Reader) {}, os.Stdout, any(3.0)),
+			ErrNewJobWrongTypeOfParameters,
 		},
 	}
 


### PR DESCRIPTION
Fixes #756.

### What does this do?
Check interface-implements if variadic parameter's types is an interface.

### Which issue(s) does this PR fix/relate to?
Resolves https://github.com/go-co-op/gocron/issues/756


### List any changes that modify/break current functionality
Nothing.

### Have you included tests for your changes?
Yes. I have added 2 test cases.

### Did you document any new/modified functionality?

- [x] Updated `scheduler_test.go`

### Notes
