### PR TITLE
issue-654: allow setting a stopTime for job.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -45,6 +45,9 @@ var (
 	ErrWithMonitorNil                = fmt.Errorf("gocron: WithMonitor: monitor must not be nil")
 	ErrWithNameEmpty                 = fmt.Errorf("gocron: WithName: name must not be empty")
 	ErrWithStartDateTimePast         = fmt.Errorf("gocron: WithStartDateTime: start must not be in the past")
+	ErrWithStopDateTimePast          = fmt.Errorf("gocron: WithStopDateTime: end must not be in the past")
+	ErrStartTimeLaterThanEndTime     = fmt.Errorf("gocron: WithStartDateTime: start must not be later than end")
+	ErrStopTimeEarlierThanStartTime  = fmt.Errorf("gocron: WithStopDateTime: end must not be earlier than start")
 	ErrWithStopTimeoutZeroOrNegative = fmt.Errorf("gocron: WithStopTimeout: timeout must be greater than 0")
 )
 

--- a/executor.go
+++ b/executor.go
@@ -146,6 +146,11 @@ func (e *executor) start() {
 						// safety check as it'd be strange bug if this occurred
 						return
 					}
+
+					if j.stopTimeReached() {
+						return
+					}
+
 					if j.singletonMode {
 						// for singleton mode, get the existing runner for the job
 						// or spin up a new one

--- a/executor.go
+++ b/executor.go
@@ -169,11 +169,6 @@ func (e *executor) start() {
 						// safety check as it'd be strange bug if this occurred
 						return
 					}
-
-					if j.stopTimeReached() {
-						return
-					}
-
 					if j.singletonMode {
 						// for singleton mode, get the existing runner for the job
 						// or spin up a new one
@@ -361,6 +356,10 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	case <-j.ctx.Done():
 		return
 	default:
+	}
+
+	if j.stopTimeReached(e.clock.Now()) {
+		return
 	}
 
 	if e.elector != nil {

--- a/job.go
+++ b/job.go
@@ -38,6 +38,7 @@ type internalJob struct {
 	limitRunsTo        *limitRunsTo
 	startTime          time.Time
 	startImmediately   bool
+	stopTime           time.Time
 	// event listeners
 	afterJobRuns          func(jobID uuid.UUID, jobName string)
 	beforeJobRuns         func(jobID uuid.UUID, jobName string)
@@ -58,6 +59,13 @@ func (j *internalJob) stop() {
 		j.timer.Stop()
 	}
 	j.cancel()
+}
+
+func (j *internalJob) stopTimeReached() bool {
+	if j.stopTime.IsZero() {
+		return false
+	}
+	return j.stopTime.Before(time.Now())
 }
 
 // task stores the function and parameters
@@ -595,7 +603,36 @@ func WithStartDateTime(start time.Time) StartAtOption {
 		if start.IsZero() || start.Before(time.Now()) {
 			return ErrWithStartDateTimePast
 		}
+		if !j.stopTime.IsZero() && j.stopTime.Before(start) {
+			return ErrStartTimeLaterThanEndTime
+		}
 		j.startTime = start
+		return nil
+	}
+}
+
+// WithStopAt sets the option for stopping the job at
+// a specific datetime.
+func WithStopAt(option StopAtOption) JobOption {
+	return func(j *internalJob) error {
+		return option(j)
+	}
+}
+
+// StopAtOption defines options for stopping the job
+type StopAtOption func(*internalJob) error
+
+// WithStopDateTime sets the final data & time after which the job should stop
+// This datetime must be in the future and should be after the startTime (if specified)
+func WithStopDateTime(end time.Time) StopAtOption {
+	return func(j *internalJob) error {
+		if end.IsZero() || end.Before(time.Now()) {
+			return ErrWithStopDateTimePast
+		}
+		if end.Before(j.startTime) {
+			return ErrStopTimeEarlierThanStartTime
+		}
+		j.stopTime = end
 		return nil
 	}
 }

--- a/job.go
+++ b/job.go
@@ -61,11 +61,11 @@ func (j *internalJob) stop() {
 	j.cancel()
 }
 
-func (j *internalJob) stopTimeReached() bool {
+func (j *internalJob) stopTimeReached(now time.Time) bool {
 	if j.stopTime.IsZero() {
 		return false
 	}
-	return j.stopTime.Before(time.Now())
+	return j.stopTime.Before(now)
 }
 
 // task stores the function and parameters
@@ -610,22 +610,23 @@ func WithStartDateTime(start time.Time) StartAtOption {
 	}
 }
 
-// WithStopAt sets the option for stopping the job at
-// a specific datetime.
+// WithStopAt sets the option for stopping the job from running
+// after the specified time.
 func WithStopAt(option StopAtOption) JobOption {
-	return func(j *internalJob) error {
-		return option(j)
+	return func(j *internalJob, now time.Time) error {
+		return option(j, now)
 	}
 }
 
 // StopAtOption defines options for stopping the job
-type StopAtOption func(*internalJob) error
+type StopAtOption func(*internalJob, time.Time) error
 
-// WithStopDateTime sets the final data & time after which the job should stop
-// This datetime must be in the future and should be after the startTime (if specified)
+// WithStopDateTime sets the final date & time after which the job should stop.
+// This must be in the future and should be after the startTime (if specified).
+// The job's final run may be at the stop time, but not after.
 func WithStopDateTime(end time.Time) StopAtOption {
-	return func(j *internalJob) error {
-		if end.IsZero() || end.Before(time.Now()) {
+	return func(j *internalJob, now time.Time) error {
+		if end.IsZero() || end.Before(now) {
 			return ErrWithStopDateTimePast
 		}
 		if end.Before(j.startTime) {

--- a/scheduler.go
+++ b/scheduler.go
@@ -325,6 +325,10 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		return
 	}
 
+	if j.stopTimeReached(s.now()) {
+		return
+	}
+
 	scheduleFrom := j.lastRun
 	if len(j.nextScheduled) > 0 {
 		// always grab the last element in the slice as that is the furthest
@@ -489,10 +493,6 @@ func (s *scheduler) selectStart() {
 		} else {
 			if next.IsZero() {
 				next = j.next(s.now())
-			}
-
-			if j.stopTimeReached() {
-				continue
 			}
 
 			jobID := id

--- a/scheduler.go
+++ b/scheduler.go
@@ -473,6 +473,10 @@ func (s *scheduler) selectStart() {
 				next = j.next(s.now())
 			}
 
+			if j.stopTimeReached() {
+				continue
+			}
+
 			jobID := id
 			j.timer = s.clock.AfterFunc(next.Sub(s.now()), func() {
 				select {


### PR DESCRIPTION
### What does this do?
This PR exposes a `stopTime` when creating a job so that the job cannot be executed once the `stopTime` is reached.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
Resolves #654 

### List any changes that modify/break current functionality


### Have you included tests for your changes?
Yes I created several test cases in `scheduler_test.go` regarding job creation with `stopTime` specified and also the expected behavior when `stopTime` is reached.

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
