### PR TITLE
handle crontab and return error with invalid day in a month

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,6 +4,7 @@ import "fmt"
 
 // Public error definitions
 var (
+	ErrCronJobInvalid                = fmt.Errorf("gocron: CronJob: invalid crontab")
 	ErrCronJobParse                  = fmt.Errorf("gocron: CronJob: crontab parse failure")
 	ErrDailyJobAtTimeNil             = fmt.Errorf("gocron: DailyJob: atTime within atTimes must not be nil")
 	ErrDailyJobAtTimesNil            = fmt.Errorf("gocron: DailyJob: atTimes must not be nil")

--- a/job.go
+++ b/job.go
@@ -116,7 +116,7 @@ type cronJobDefinition struct {
 	withSeconds bool
 }
 
-func (c cronJobDefinition) setup(j *internalJob, location *time.Location, _ time.Time) error {
+func (c cronJobDefinition) setup(j *internalJob, location *time.Location, now time.Time) error {
 	var withLocation string
 	if strings.HasPrefix(c.crontab, "TZ=") || strings.HasPrefix(c.crontab, "CRON_TZ=") {
 		withLocation = c.crontab
@@ -139,6 +139,9 @@ func (c cronJobDefinition) setup(j *internalJob, location *time.Location, _ time
 	}
 	if err != nil {
 		return errors.Join(ErrCronJobParse, err)
+	}
+	if cronSchedule.Next(now).IsZero() {
+		return ErrCronJobInvalid
 	}
 
 	j.jobSchedule = &cronJob{cronSchedule: cronSchedule}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -533,6 +533,15 @@ func TestScheduler_NewJobErrors(t *testing.T) {
 			ErrCronJobParse,
 		},
 		{
+			"cron invalid date",
+			CronJob(
+				"* * * 31 FEB *",
+				true,
+			),
+			nil,
+			ErrCronJobInvalid,
+		},
+		{
 			"duration job time interval is zero",
 			DurationJob(0 * time.Second),
 			nil,


### PR DESCRIPTION
### What does this do?
an invalid cron month day doesn't fail to parse as it's not "invalid" from a syntax perspective. Adding an additional check, if the cron schedule returns a zero time, signaling the crontab is invalid

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #765 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
