### PR TITLE
feat: add lock update mechanism for jobs, closes #762

### DIFF
--- a/job.go
+++ b/job.go
@@ -30,6 +30,7 @@ type internalJob struct {
 	nextScheduled []time.Time
 
 	lastRun            time.Time
+	lastLock           Lock
 	function           any
 	parameters         []any
 	timer              clockwork.Timer
@@ -1026,6 +1027,7 @@ type Job interface {
 	RunNow() error
 	// Tags returns the job's string tags.
 	Tags() []string
+	Lock() Lock
 }
 
 var _ Job = (*job)(nil)
@@ -1125,4 +1127,10 @@ func (j job) RunNow() error {
 		err = errReceived
 	}
 	return err
+}
+
+func (j job) Lock() Lock {
+	ij := requestJob(j.id, j.jobOutRequest)
+
+	return ij.lastLock
 }


### PR DESCRIPTION
- Add `jobOutUpdateLockRequest` channel in the executor
- Implement lock update requests in the job execution process
- Add `Lock()` method to the `Job` interface
- Update the scheduler to handle lock update requests
- Add a test case to verify the new locking mechanism
