### PR TITLE
feat: add Context() method and update job retrieval, closes #762

### DIFF
--- a/job.go
+++ b/job.go
@@ -30,6 +30,7 @@ type internalJob struct {
 	nextScheduled []time.Time
 
 	lastRun            time.Time
+	lastLock           Lock
 	function           any
 	parameters         []any
 	timer              clockwork.Timer
@@ -1026,6 +1027,7 @@ type Job interface {
 	RunNow() error
 	// Tags returns the job's string tags.
 	Tags() []string
+	Lock() Lock
 }
 
 var _ Job = (*job)(nil)
@@ -1125,4 +1127,10 @@ func (j job) RunNow() error {
 		err = errReceived
 	}
 	return err
+}
+
+func (j job) Lock() Lock {
+	ij := requestJob(j.id, j.jobOutRequest)
+
+	return ij.lastLock
 }

--- a/job.go
+++ b/job.go
@@ -1028,6 +1028,7 @@ type Job interface {
 	// Tags returns the job's string tags.
 	Tags() []string
 	Lock() Lock
+	Context() context.Context
 }
 
 var _ Job = (*job)(nil)
@@ -1049,7 +1050,7 @@ func (j job) ID() uuid.UUID {
 }
 
 func (j job) LastRun() (time.Time, error) {
-	ij := requestJob(j.id, j.jobOutRequest)
+	ij := requestJob(j.id, j.jobOutRequest, true)
 	if ij == nil || ij.id == uuid.Nil {
 		return time.Time{}, ErrJobNotFound
 	}
@@ -1061,7 +1062,7 @@ func (j job) Name() string {
 }
 
 func (j job) NextRun() (time.Time, error) {
-	ij := requestJob(j.id, j.jobOutRequest)
+	ij := requestJob(j.id, j.jobOutRequest, true)
 	if ij == nil || ij.id == uuid.Nil {
 		return time.Time{}, ErrJobNotFound
 	}
@@ -1074,7 +1075,7 @@ func (j job) NextRun() (time.Time, error) {
 }
 
 func (j job) NextRuns(count int) ([]time.Time, error) {
-	ij := requestJob(j.id, j.jobOutRequest)
+	ij := requestJob(j.id, j.jobOutRequest, true)
 	if ij == nil || ij.id == uuid.Nil {
 		return nil, ErrJobNotFound
 	}
@@ -1130,7 +1131,13 @@ func (j job) RunNow() error {
 }
 
 func (j job) Lock() Lock {
-	ij := requestJob(j.id, j.jobOutRequest)
+	ij := requestJob(j.id, j.jobOutRequest, true)
 
 	return ij.lastLock
+}
+
+func (j job) Context() context.Context {
+	ij := requestJob(j.id, j.jobOutRequest, false)
+
+	return ij.ctx
 }

--- a/util.go
+++ b/util.go
@@ -36,9 +36,15 @@ func callJobFuncWithParams(jobFunc any, params ...any) error {
 	return nil
 }
 
-func requestJob(id uuid.UUID, ch chan jobOutRequest) *internalJob {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+func requestJob(id uuid.UUID, ch chan jobOutRequest, timeout bool) *internalJob {
+	var cancel context.CancelFunc
+	ctx := context.Background()
+
+	if timeout {
+		ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+	}
+
 	return requestJobCtx(ctx, id, ch)
 }
 


### PR DESCRIPTION
- Add Context() method to Job interface and implement it in job struct
- Update requestJob function to include a timeout flag
- Modify existing methods to use the new requestJob signature

depends on #786