### PR TITLE
stop timeout timers when no longer needed

### DIFF
--- a/job.go
+++ b/job.go
@@ -1099,12 +1099,14 @@ func (j job) RunNow() error {
 	defer cancel()
 	resp := make(chan error, 1)
 
+	t := time.NewTimer(100 * time.Millisecond)
 	select {
 	case j.runJobRequest <- runJobRequest{
 		id:      j.id,
 		outChan: resp,
 	}:
-	case <-time.After(100 * time.Millisecond):
+		t.Stop()
+	case <-t.C:
 		return ErrJobRunNowFailed
 	}
 	var err error

--- a/scheduler.go
+++ b/scheduler.go
@@ -241,9 +241,11 @@ func (s *scheduler) stopScheduler() {
 	}
 	var err error
 	if s.started {
+		t := time.NewTimer(s.exec.stopTimeout + 1*time.Second)
 		select {
 		case err = <-s.exec.done:
-		case <-time.After(s.exec.stopTimeout + 1*time.Second):
+			t.Stop()
+		case <-t.C:
 			err = ErrStopExecutorTimedOut
 		}
 	}
@@ -741,20 +743,27 @@ func (s *scheduler) StopJobs() error {
 		return nil
 	case s.stopCh <- struct{}{}:
 	}
+
+	t := time.NewTimer(s.exec.stopTimeout + 2*time.Second)
 	select {
 	case err := <-s.stopErrCh:
+		t.Stop()
 		return err
-	case <-time.After(s.exec.stopTimeout + 2*time.Second):
+	case <-t.C:
 		return ErrStopSchedulerTimedOut
 	}
 }
 
 func (s *scheduler) Shutdown() error {
 	s.shutdownCancel()
+
+	t := time.NewTimer(s.exec.stopTimeout + 2*time.Second)
 	select {
 	case err := <-s.stopErrCh:
+
+		t.Stop()
 		return err
-	case <-time.After(s.exec.stopTimeout + 2*time.Second):
+	case <-t.C:
 		return ErrStopSchedulerTimedOut
 	}
 }


### PR DESCRIPTION
### What does this do?
Convert all uses of `time.After` to use `time.NewTimer` and then call `Stop()` if we don't hit the timer.

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves #802 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
