### PR TITLE
parse time.Time from AtTime

### DIFF
--- a/job.go
+++ b/job.go
@@ -413,6 +413,14 @@ func (a atTime) time(location *time.Location) time.Time {
 	return time.Date(0, 0, 0, int(a.hours), int(a.minutes), int(a.seconds), 0, location)
 }
 
+// TimeFromAtTime is a helper function to allow converting AtTime into a time.Time value
+// Note: the time.Time value will have zero values for all Time fields except Hours, Minutes, Seconds.
+//
+//	For example: time.Date(0, 0, 0, 1, 1, 1, 0, time.UTC)
+func TimeFromAtTime(at AtTime, loc *time.Location) time.Time {
+	return at().time(loc)
+}
+
 // AtTime defines a function that returns the internal atTime
 type AtTime func() atTime
 

--- a/job_test.go
+++ b/job_test.go
@@ -676,3 +676,51 @@ func TestJob_PanicOccurred(t *testing.T) {
 	close(gotCh)
 	close(errCh)
 }
+
+func TestTimeFromAtTime(t *testing.T) {
+	testTimeUTC := time.Date(0, 0, 0, 1, 1, 1, 0, time.UTC)
+	cst, err := time.LoadLocation("America/Chicago")
+	require.NoError(t, err)
+	testTimeCST := time.Date(0, 0, 0, 1, 1, 1, 0, cst)
+
+	tests := []struct {
+		name         string
+		at           AtTime
+		loc          *time.Location
+		expectedTime time.Time
+		expectedStr  string
+	}{
+		{
+			"UTC",
+			NewAtTime(
+				uint(testTimeUTC.Hour()),
+				uint(testTimeUTC.Minute()),
+				uint(testTimeUTC.Second()),
+			),
+			time.UTC,
+			testTimeUTC,
+			"01:01:01",
+		},
+		{
+			"CST",
+			NewAtTime(
+				uint(testTimeCST.Hour()),
+				uint(testTimeCST.Minute()),
+				uint(testTimeCST.Second()),
+			),
+			cst,
+			testTimeCST,
+			"01:01:01",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TimeFromAtTime(tt.at, tt.loc)
+			assert.Equal(t, tt.expectedTime, result)
+
+			resultFmt := result.Format("15:04:05")
+			assert.Equal(t, tt.expectedStr, resultFmt)
+		})
+	}
+}


### PR DESCRIPTION
### What does this do?
```go
// TimeFromAtTime is a helper function to allow converting AtTime into a time.Time value
// Note: the time.Time value will have zero values for all Time fields except Hours, Minutes, Seconds.
//
//	For example: time.Date(0, 0, 0, 1, 1, 1, 0, time.UTC)
```

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
related #805 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
