### PR TITLE
fixes related to the bug where a job unexpectedly runs twice

### DIFF
--- a/job.go
+++ b/job.go
@@ -818,7 +818,7 @@ func (d dailyJob) next(lastRun time.Time) time.Time {
 	}
 	firstPass = false
 
-	startNextDay := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day()+int(d.interval), 0, 0, 0, lastRun.Nanosecond(), lastRun.Location())
+	startNextDay := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day()+int(d.interval), 0, 0, 0, 0, lastRun.Location())
 	return d.nextDay(startNextDay, firstPass)
 }
 
@@ -826,7 +826,7 @@ func (d dailyJob) nextDay(lastRun time.Time, firstPass bool) time.Time {
 	for _, at := range d.atTimes {
 		// sub the at time hour/min/sec onto the lastScheduledRun's values
 		// to use in checks to see if we've got our next run time
-		atDate := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day(), at.Hour(), at.Minute(), at.Second(), lastRun.Nanosecond(), lastRun.Location())
+		atDate := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day(), at.Hour(), at.Minute(), at.Second(), 0, lastRun.Location())
 
 		if firstPass && atDate.After(lastRun) {
 			// checking to see if it is after i.e. greater than,
@@ -872,7 +872,7 @@ func (w weeklyJob) nextWeekDayAtTime(lastRun time.Time, firstPass bool) time.Tim
 			for _, at := range w.atTimes {
 				// sub the at time hour/min/sec onto the lastScheduledRun's values
 				// to use in checks to see if we've got our next run time
-				atDate := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day()+int(weekDayDiff), at.Hour(), at.Minute(), at.Second(), lastRun.Nanosecond(), lastRun.Location())
+				atDate := time.Date(lastRun.Year(), lastRun.Month(), lastRun.Day()+int(weekDayDiff), at.Hour(), at.Minute(), at.Second(), 0, lastRun.Location())
 
 				if firstPass && atDate.After(lastRun) {
 					// checking to see if it is after i.e. greater than,
@@ -940,7 +940,7 @@ func (m monthlyJob) nextMonthDayAtTime(lastRun time.Time, days []int, firstPass 
 			for _, at := range m.atTimes {
 				// sub the day, and the at time hour/min/sec onto the lastScheduledRun's values
 				// to use in checks to see if we've got our next run time
-				atDate := time.Date(lastRun.Year(), lastRun.Month(), day, at.Hour(), at.Minute(), at.Second(), lastRun.Nanosecond(), lastRun.Location())
+				atDate := time.Date(lastRun.Year(), lastRun.Month(), day, at.Hour(), at.Minute(), at.Second(), 0, lastRun.Location())
 
 				if atDate.Month() != lastRun.Month() {
 					// this check handles if we're setting a day not in the current month

--- a/scheduler.go
+++ b/scheduler.go
@@ -331,7 +331,7 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		return
 	}
 
-	scheduleFrom := j.lastRun
+	var scheduleFrom time.Time
 	if len(j.nextScheduled) > 0 {
 		// always grab the last element in the slice as that is the furthest
 		// out in the future and the time from which we want to calculate
@@ -358,6 +358,15 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		// in those cases, we want to increment to the next run in the future
 		// and schedule the job for that time.
 		for next.Before(s.now()) {
+			next = j.next(next)
+		}
+	}
+
+	if slices.Contains(j.nextScheduled, next) {
+		// if the next value is a duplicate of what's already in the nextScheduled slice, for example:
+		// - the job is being rescheduled off the same next run value as before
+		// increment to the next, next value
+		for slices.Contains(j.nextScheduled, next) {
 			next = j.next(next)
 		}
 	}


### PR DESCRIPTION
### What does this do?

Addresses edge cases that could result in a job running twice unexpectedly. 

There are reports of jobs being run very close together when they should not be -> #789.

What this fixes:
- In the daily, weekly and monthly `next()` functions, the `nanosecond` time values were being included inconsistently on the day calculations. Since `AtTime` only considers hour, min, sec, there is risk in including the nanosecond values, as I could see it resulting in next run values being incorrect. Instead, just anchoring to zero nanoseconds.
- In the scheduler's reschedule logic, check to make sure we're not adding duplicate time values to the `nextScheduled` slice. Since this is used to schedule from, having a duplicate value could result in the same time being set for the job to run

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
