### PR TITLE
feat(beforeJobError): introduce BeforeJobError as a new Eventlistener

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -389,7 +389,12 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 		}
 		defer func() { _ = lock.Unlock(j.ctx) }()
 	}
-	_ = callJobFuncWithParams(j.beforeJobRuns, j.id, j.name)
+	
+	err := callJobFuncWithParams(j.beforeJobRuns, j.id, j.name)
+	if err != nil {
+		fmt.Println("error before script")
+		return 
+	}
 
 	e.sendOutForRescheduling(&jIn)
 	select {
@@ -398,7 +403,6 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	}
 
 	startTime := time.Now()
-	var err error
 	if j.afterJobRunsWithPanic != nil {
 		err = e.callJobWithRecover(j)
 	} else {


### PR DESCRIPTION
### What does this do?
This PR adds a new `EventListener` `BeforeJobRunsError` that exits job execution if the provided func returns an error

**Use Case**:
Im using `gocron` as a command wrapper for `terraform` to perform synthetic monitoring checks and came up with a configuration as follows:

```yaml
settings:
  interval: 10s
  extra_labels:
    development: true

tests:
  vmware_vm:
    env:
      TF_VAR_content: "This is a variable"

    before_script:
      - cmd: terraform init
        retries: 2

    script:
      - cmd: terraform apply -auto-approve

    after_script:
      - cmd: terraform destroy -auto-approve
```

Where as the commands specified in the `before_script` block would be passed to `BeforeJobRuns()`, without this PR there was no way to stop the currents jobs execution in case of an error in one of the commands in `before_script`. 

Introducing `BeforeJobRunsError` allows me to exit the jobs execution gracefully and try again after the configured interval.

### List any changes that modify/break current functionality
`none`

### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
