### PR TITLE
feat(event listener): introduce BeforeJobRunsSkipIfBeforeFuncErrors as a new Eventlistener

### DIFF
--- a/.github/workflows/file_formatting.yml
+++ b/.github/workflows/file_formatting.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v4
       - name: verify example_test.go
         run: |
-          grep "^func " example_test.go | sort -c
+          grep "^func [a-z-A-Z]" example_test.go | sort -c

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ fmt:
 	@go list -f {{.Dir}} ./... | xargs -I{} gofmt -w -s {}
 
 lint:
-	@grep "^func " example_test.go | sort -c
+	@grep "^func [a-zA-Z]" example_test.go | sort -c
 	@golangci-lint run
 
 test:

--- a/example_test.go
+++ b/example_test.go
@@ -104,6 +104,29 @@ func ExampleBeforeJobRuns() {
 	)
 }
 
+func ExampleBeforeJobRunsSkipIfBeforeFuncErrors() {
+	s, _ := gocron.NewScheduler()
+	defer func() { _ = s.Shutdown() }()
+
+	_, _ = s.NewJob(
+		gocron.DurationJob(
+			time.Second,
+		),
+		gocron.NewTask(
+			func() {
+				fmt.Println("Will never run, because before job func errors")
+			},
+		),
+		gocron.WithEventListeners(
+			gocron.BeforeJobRunsSkipIfBeforeFuncErrors(
+				func(jobID uuid.UUID, jobName string) error {
+					return fmt.Errorf("error")
+				},
+			),
+		),
+	)
+}
+
 func ExampleCronJob() {
 	s, _ := gocron.NewScheduler()
 	defer func() { _ = s.Shutdown() }()

--- a/job_test.go
+++ b/job_test.go
@@ -482,6 +482,13 @@ func TestWithEventListeners(t *testing.T) {
 			},
 			ErrEventListenerFuncNil,
 		},
+		{
+			"nil before job runs error listener",
+			[]EventListener{
+				BeforeJobRunsSkipIfBeforeFuncErrors(nil),
+			},
+			ErrEventListenerFuncNil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this do?
This PR adds a new `EventListener` `BeforeJobRunsSkipIfBeforeFuncErrors` that exits job execution if the provided func returns an error

**Use Case**:
Im using `gocron` as a command wrapper for `terraform` to perform synthetic monitoring checks and came up with a configuration as follows:

```yaml
settings:
  interval: 10s
  extra_labels:
    development: true

tests:
  vmware_vm:
    env:
      TF_VAR_content: "This is a variable"

    before_script:
      - cmd: terraform init
        retries: 2

    script:
      - cmd: terraform apply -auto-approve

    after_script:
      - cmd: terraform destroy -auto-approve
```

Where as the commands specified in the `before_script` block would be passed to `BeforeJobRuns()`, without this PR there was no way to stop the currents jobs execution in case of an error in any of the commands in `before_script`. 

Introducing `BeforeJobRunsSkipIfBeforeFuncErrors` allows me to exit the jobs execution gracefully and reschedule to job after the given interval.

### List any changes that modify/break current functionality
`none`

### Have you included tests for your changes?
Si

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
