### PR TITLE
cancel running jobs if possible when run Scheduler.StopJobs()

### DIFF
--- a/job.go
+++ b/job.go
@@ -706,7 +706,7 @@ func WithIdentifier(id uuid.UUID) JobOption {
 
 // WithContext sets the parent context for the job
 func WithContext(ctx context.Context) JobOption {
-	return func(j *internalJob, now time.Time) error {
+	return func(j *internalJob, _ time.Time) error {
 		j.parentCtx = ctx
 		return nil
 	}

--- a/job.go
+++ b/job.go
@@ -18,11 +18,12 @@ import (
 // internalJob stores the information needed by the scheduler
 // to manage scheduling, starting and stopping the job
 type internalJob struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-	id     uuid.UUID
-	name   string
-	tags   []string
+	ctx       context.Context
+	parentCtx context.Context
+	cancel    context.CancelFunc
+	id        uuid.UUID
+	name      string
+	tags      []string
 	jobSchedule
 
 	// as some jobs may queue up, it's possible to
@@ -699,6 +700,14 @@ func WithIdentifier(id uuid.UUID) JobOption {
 		}
 
 		j.id = id
+		return nil
+	}
+}
+
+// WithContext sets the parent context for the job
+func WithContext(ctx context.Context) JobOption {
+	return func(j *internalJob, now time.Time) error {
+		j.parentCtx = ctx
 		return nil
 	}
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -648,8 +648,6 @@ func (s *scheduler) addOrUpdateJob(id uuid.UUID, definition JobDefinition, taskW
 		j.id = id
 	}
 
-	j.ctx, j.cancel = context.WithCancel(s.shutdownCtx)
-
 	if taskWrapper == nil {
 		return nil, ErrNewJobTaskNil
 	}
@@ -662,10 +660,6 @@ func (s *scheduler) addOrUpdateJob(id uuid.UUID, definition JobDefinition, taskW
 
 	if taskFunc.Kind() != reflect.Func {
 		return nil, ErrNewJobTaskNotFunc
-	}
-
-	if err := s.verifyParameterType(taskFunc, tsk); err != nil {
-		return nil, err
 	}
 
 	j.name = runtime.FuncForPC(taskFunc.Pointer()).Name()
@@ -684,6 +678,28 @@ func (s *scheduler) addOrUpdateJob(id uuid.UUID, definition JobDefinition, taskW
 		if err := option(&j, s.now()); err != nil {
 			return nil, err
 		}
+	}
+
+	if j.parentCtx == nil {
+		j.parentCtx = s.shutdownCtx
+	}
+	j.ctx, j.cancel = context.WithCancel(j.parentCtx)
+
+	if !taskFunc.IsZero() && taskFunc.Type().NumIn() > 0 {
+		// if the first parameter is a context.Context and params have no context.Context, add current ctx to the params
+		if taskFunc.Type().In(0) == reflect.TypeOf((*context.Context)(nil)).Elem() {
+			if len(tsk.parameters) == 0 {
+				tsk.parameters = []any{j.ctx}
+				j.parameters = []any{j.ctx}
+			} else if _, ok := tsk.parameters[0].(context.Context); !ok {
+				tsk.parameters = append([]any{j.ctx}, tsk.parameters...)
+				j.parameters = append([]any{j.ctx}, j.parameters...)
+			}
+		}
+	}
+
+	if err := s.verifyParameterType(taskFunc, tsk); err != nil {
+		return nil, err
 	}
 
 	if err := definition.setup(&j, s.location, s.exec.clock.Now()); err != nil {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -361,6 +361,42 @@ func TestScheduler_StopTimeout(t *testing.T) {
 	}
 }
 
+func TestScheduler_StopLongRunningJobs(t *testing.T) {
+	t.Run("start, run job, stop jobs before job is completed", func(t *testing.T) {
+		s := newTestScheduler(t,
+			WithStopTimeout(50*time.Millisecond),
+		)
+
+		_, err := s.NewJob(
+			DurationJob(
+				50*time.Millisecond,
+			),
+			NewTask(
+				func(ctx context.Context) {
+					select {
+					case <-ctx.Done():
+						time.Sleep(time.Second)
+					case <-time.After(100 * time.Millisecond):
+						t.Fatal("job can not been canceled")
+					}
+				},
+			),
+			WithStartAt(
+				WithStartImmediately(),
+			),
+			WithSingletonMode(LimitModeReschedule),
+		)
+		require.NoError(t, err)
+
+		s.Start()
+
+		time.Sleep(20 * time.Millisecond)
+		// the running job is canceled, no unexpected timeout error
+		require.NoError(t, s.StopJobs())
+		time.Sleep(100 * time.Millisecond)
+	})
+}
+
 func TestScheduler_Shutdown(t *testing.T) {
 	defer verifyNoGoroutineLeaks(t)
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -375,7 +375,6 @@ func TestScheduler_StopLongRunningJobs(t *testing.T) {
 				func(ctx context.Context) {
 					select {
 					case <-ctx.Done():
-						time.Sleep(time.Second)
 					case <-time.After(100 * time.Millisecond):
 						t.Fatal("job can not been canceled")
 					}


### PR DESCRIPTION
### What does this do?

when run Scheduler.StopJobs(), the scheduler will wait for the running jobs to be completed. If there are long running jobs, it will always return "timed out waiting for jobs to finish".

This pr try to cancel the running jobs if possible

### Which issue(s) does this PR fix/relate to?
Resolves #818


### List any changes that modify/break current functionality
You can now add a task function which accept ctx as the first param, but you do need pass a ctx actually, gocron will handle it properly
```
	j, err := s.NewJob(
		gocron.DurationJob(
			10*time.Second,
		),
		gocron.NewTask(
			func(ctx context.Context) {
				// do things
			},
		),
	)
```
but if you have you own ctx, fell free to pass it
```
	j, err := s.NewJob(
		gocron.DurationJob(
			10*time.Second,
		),
		gocron.NewTask(
			func(ctx context.Context) {
				// do things
			},
                         ctx,
		),
	)
```
or you can also pass it as a job option to control the whole thing
```
	j, err := s.NewJob(
		gocron.DurationJob(
			10*time.Second,
		),
		gocron.NewTask(
			func(ctx context.Context) {
				// do things
			},
		),
                gocron.WithContext(ctx)
	)
```


### Have you included tests for your changes?
yes

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
