### PR TITLE
replace "golang.org/x/exp" with standard libraries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/goleak v1.3.0
-	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
-golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/job.go
+++ b/job.go
@@ -6,13 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"github.com/robfig/cron/v3"
-	"golang.org/x/exp/slices"
 )
 
 // internalJob stores the information needed by the scheduler
@@ -369,11 +369,9 @@ func (m monthlyJobDefinition) setup(j *internalJob, location *time.Location, _ t
 		}
 	}
 	daysStart = removeSliceDuplicatesInt(daysStart)
-	slices.Sort(daysStart)
 	ms.days = daysStart
 
 	daysEnd = removeSliceDuplicatesInt(daysEnd)
-	slices.Sort(daysEnd)
 	ms.daysFromEnd = daysEnd
 
 	atTimesDate, err := convertAtTimesToDateTime(m.atTimes, location)

--- a/scheduler.go
+++ b/scheduler.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"reflect"
 	"runtime"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
-	"golang.org/x/exp/slices"
 )
 
 var _ Scheduler = (*scheduler)(nil)
@@ -267,14 +268,7 @@ func (s *scheduler) selectAllJobsOutRequest(out allJobsOutRequest) {
 	}
 	slices.SortFunc(outJobs, func(a, b Job) int {
 		aID, bID := a.ID().String(), b.ID().String()
-		switch {
-		case aID < bID:
-			return -1
-		case aID > bID:
-			return 1
-		default:
-			return 0
-		}
+		return strings.Compare(aID, bID)
 	})
 	select {
 	case <-s.shutdownCtx.Done():

--- a/util.go
+++ b/util.go
@@ -3,12 +3,11 @@ package gocron
 import (
 	"context"
 	"reflect"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/google/uuid"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 func callJobFuncWithParams(jobFunc any, params ...any) error {
@@ -63,12 +62,8 @@ func requestJobCtx(ctx context.Context, id uuid.UUID, ch chan jobOutRequest) *in
 }
 
 func removeSliceDuplicatesInt(in []int) []int {
-	m := make(map[int]struct{})
-
-	for _, i := range in {
-		m[i] = struct{}{}
-	}
-	return maps.Keys(m)
+	slices.Sort(in)
+	return slices.Compact(in)
 }
 
 func convertAtTimesToDateTime(atTimes AtTimes, location *time.Location) ([]time.Time, error) {


### PR DESCRIPTION
### What does this do?

Since gocron requires go1.21.0+, we can replace "golang.org/x/exp/maps" and "golang.org/x/exp/slices" with the standard libraries "maps" and "slices". BTW, "golang.org/x/exp/slices" now is only a wrapper of "slice".


### Which issue(s) does this PR fix/relate to?


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

### Notes

"removeSliceDuplicatesInt" could also get some performance benifits:

```go
func BenchmarkRemoveSliceDuplicatesInt(b *testing.B) {
	for range b.N {
		removeSliceDuplicatesInt([]int{1, 4, 5, 4, 6, 2, 3})
	}
}
```

```text
goos: windows
goarch: amd64
pkg: bench
cpu: Intel(R) Core(TM) i5-10200H CPU @ 2.40GHz
                           │     old      │                 new                 │
                           │    sec/op    │   sec/op     vs base                │
RemoveSliceDuplicatesInt-8   285.00n ± 1%   29.75n ± 0%  -89.56% (p=0.000 n=10)

                           │    old     │                new                 │
                           │    B/op    │   B/op     vs base                 │
RemoveSliceDuplicatesInt-8   96.00 ± 0%   0.00 ± 0%  -100.00% (p=0.000 n=10)

                           │    old     │                 new                 │
                           │ allocs/op  │ allocs/op   vs base                 │
RemoveSliceDuplicatesInt-8   3.000 ± 0%   0.000 ± 0%  -100.00% (p=0.000 n=10)
```

As an added benefit, there is now no need to sort the results of “removeSliceDuplicatesInt” because they are already sorted.