### PR TITLE
fix scheduler restart

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -241,7 +241,17 @@ func (s *scheduler) stopScheduler() {
 	for id, j := range s.jobs {
 		<-j.ctx.Done()
 
-		j.ctx, j.cancel = context.WithCancel(s.shutdownCtx)
+		oldCtx := j.ctx
+		if j.parentCtx == nil {
+			j.parentCtx = s.shutdownCtx
+		}
+		j.ctx, j.cancel = context.WithCancel(j.parentCtx)
+
+		// also replace the old context with the new one in the parameters
+		if len(j.parameters) > 0 && j.parameters[0] == oldCtx {
+			j.parameters[0] = j.ctx
+		}
+
 		s.jobs[id] = j
 	}
 	var err error

--- a/scheduler.go
+++ b/scheduler.go
@@ -238,9 +238,20 @@ func (s *scheduler) stopScheduler() {
 	for _, j := range s.jobs {
 		j.stop()
 	}
-	for id, j := range s.jobs {
+	for _, j := range s.jobs {
 		<-j.ctx.Done()
-
+	}
+	var err error
+	if s.started {
+		t := time.NewTimer(s.exec.stopTimeout + 1*time.Second)
+		select {
+		case err = <-s.exec.done:
+			t.Stop()
+		case <-t.C:
+			err = ErrStopExecutorTimedOut
+		}
+	}
+	for id, j := range s.jobs {
 		oldCtx := j.ctx
 		if j.parentCtx == nil {
 			j.parentCtx = s.shutdownCtx
@@ -254,16 +265,7 @@ func (s *scheduler) stopScheduler() {
 
 		s.jobs[id] = j
 	}
-	var err error
-	if s.started {
-		t := time.NewTimer(s.exec.stopTimeout + 1*time.Second)
-		select {
-		case err = <-s.exec.done:
-			t.Stop()
-		case <-t.C:
-			err = ErrStopExecutorTimedOut
-		}
-	}
+
 	s.stopErrCh <- err
 	s.started = false
 	s.logger.Debug("gocron: scheduler stopped")


### PR DESCRIPTION
### What does this do?

There is an issue introduced by https://github.com/go-co-op/gocron/pull/819

Steps to reproduce:
1. use a job function starts with ctx and do not pass an ctx
2. stop the scheduler by running .StopJobs()
3. start the scheduler by running .Start()
4. the job function does not work properly since ctx is already cancelled

This pr fix it by updating the ctx after job is stopped

### Which issue(s) does this PR fix/relate to?

related to https://github.com/go-co-op/gocron/pull/819

### List any changes that modify/break current functionality


### Have you included tests for your changes?
yes

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
