### PR TITLE
fix err assertion in TestScheduler_RemoveJob

### DIFF
--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1839,7 +1839,7 @@ func TestScheduler_RemoveJob(t *testing.T) {
 			}
 
 			err := s.RemoveJob(id)
-			assert.ErrorIs(t, err, err)
+			assert.ErrorIs(t, err, tt.err)
 			require.NoError(t, s.Shutdown())
 		})
 	}


### PR DESCRIPTION
### What does this do?

This PR fixes `TestScheduler_RemoveJob`.

### Notes

`assert.ErrorIs(t, err, err)` is useless and clearly a mistake. It should be `assert.ErrorIs(t, err, tt.err)`.