### PR TITLE
Fix #835 and #837

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -141,7 +141,7 @@ func NewScheduler(options ...SchedulerOption) (Scheduler, error) {
 		jobUpdateNextRuns:      make(chan uuid.UUID),
 		jobsOutCompleted:       make(chan uuid.UUID),
 		jobOutRequest:          make(chan jobOutRequest, 1000),
-		done:                   make(chan error),
+		done:                   make(chan error, 1),
 	}
 
 	s := &scheduler{


### PR DESCRIPTION
### What does this do?

Fixes #835.
Fixes #837.

For 837: `e.stopCh` now has only one receiver, and if `executorCtx.Done()` does not block, it means that the executor has already received the stop signal and called the stop method, so there is no need to do additional operations, just return from the sub-goroutine.
I also use `sync.Once` to prevent the stop method from being called multiple times before the next call to the start method. This may not be necessary, but it maximizes concurrency security, and it doesn't do any noticeable harm.

### Which issue(s) does this PR fix/relate to?

#835 
#837 


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes

The two issues have some relevance, so I put the fixes in the same PR. Please don't sqush the commits.
