### PR TITLE
feat: add lock update mechanism for jobs, closes #762

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -30,6 +30,8 @@ type executor struct {
 	jobsOutCompleted chan uuid.UUID
 	// used to request jobs from the scheduler
 	jobOutRequest chan jobOutRequest
+	// used to request jobs from the scheduler
+	jobOutUpdateLockRequest chan jobOutUpdateLockRequest
 
 	// sends out job needs to update the next runs
 	jobUpdateNextRuns chan uuid.UUID
@@ -392,7 +394,14 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 			e.sendOutForNextRunUpdate(&jIn)
 			return
 		}
-		defer func() { _ = lock.Unlock(j.ctx) }()
+		e.jobOutUpdateLockRequest <- jobOutUpdateLockRequest{
+			id:   j.id,
+			lock: lock,
+		}
+
+		defer func() {
+			_ = lock.Unlock(j.ctx)
+		}()
 	} else if !j.disabledLocker && e.locker != nil {
 		lock, err := e.locker.Lock(j.ctx, j.name)
 		if err != nil {
@@ -402,7 +411,14 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 			e.sendOutForNextRunUpdate(&jIn)
 			return
 		}
-		defer func() { _ = lock.Unlock(j.ctx) }()
+		e.jobOutUpdateLockRequest <- jobOutUpdateLockRequest{
+			id:   j.id,
+			lock: lock,
+		}
+
+		defer func() {
+			_ = lock.Unlock(j.ctx)
+		}()
 	}
 
 	_ = callJobFuncWithParams(j.beforeJobRuns, j.id, j.name)

--- a/job.go
+++ b/job.go
@@ -32,6 +32,7 @@ type internalJob struct {
 	nextScheduled []time.Time
 
 	lastRun            time.Time
+	lastLock           Lock
 	function           any
 	parameters         []any
 	timer              clockwork.Timer
@@ -1124,6 +1125,7 @@ type Job interface {
 	RunNow() error
 	// Tags returns the job's string tags.
 	Tags() []string
+	Lock() Lock
 }
 
 var _ Job = (*job)(nil)
@@ -1223,4 +1225,10 @@ func (j job) RunNow() error {
 		err = errReceived
 	}
 	return err
+}
+
+func (j job) Lock() Lock {
+	ij := requestJob(j.id, j.jobOutRequest)
+
+	return ij.lastLock
 }

--- a/mocks/job.go
+++ b/mocks/job.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -destination=mocks/job.go -package=gocronmocks . Job
 //
+
 // Package gocronmocks is a generated GoMock package.
 package gocronmocks
 
@@ -12,6 +13,7 @@ import (
 	reflect "reflect"
 	time "time"
 
+	v2 "github.com/go-co-op/gocron/v2"
 	uuid "github.com/google/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -20,6 +22,7 @@ import (
 type MockJob struct {
 	ctrl     *gomock.Controller
 	recorder *MockJobMockRecorder
+	isgomock struct{}
 }
 
 // MockJobMockRecorder is the mock recorder for MockJob.
@@ -66,6 +69,20 @@ func (m *MockJob) LastRun() (time.Time, error) {
 func (mr *MockJobMockRecorder) LastRun() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastRun", reflect.TypeOf((*MockJob)(nil).LastRun))
+}
+
+// Lock mocks base method.
+func (m *MockJob) Lock() v2.Lock {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Lock")
+	ret0, _ := ret[0].(v2.Lock)
+	return ret0
+}
+
+// Lock indicates an expected call of Lock.
+func (mr *MockJobMockRecorder) Lock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lock", reflect.TypeOf((*MockJob)(nil).Lock))
 }
 
 // Name mocks base method.

--- a/mocks/scheduler.go
+++ b/mocks/scheduler.go
@@ -5,13 +5,14 @@
 //
 //	mockgen -destination=mocks/scheduler.go -package=gocronmocks . Scheduler
 //
+
 // Package gocronmocks is a generated GoMock package.
 package gocronmocks
 
 import (
 	reflect "reflect"
 
-	gocron "github.com/go-co-op/gocron/v2"
+	v2 "github.com/go-co-op/gocron/v2"
 	uuid "github.com/google/uuid"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -20,6 +21,7 @@ import (
 type MockScheduler struct {
 	ctrl     *gomock.Controller
 	recorder *MockSchedulerMockRecorder
+	isgomock struct{}
 }
 
 // MockSchedulerMockRecorder is the mock recorder for MockScheduler.
@@ -40,10 +42,10 @@ func (m *MockScheduler) EXPECT() *MockSchedulerMockRecorder {
 }
 
 // Jobs mocks base method.
-func (m *MockScheduler) Jobs() []gocron.Job {
+func (m *MockScheduler) Jobs() []v2.Job {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jobs")
-	ret0, _ := ret[0].([]gocron.Job)
+	ret0, _ := ret[0].([]v2.Job)
 	return ret0
 }
 
@@ -68,14 +70,14 @@ func (mr *MockSchedulerMockRecorder) JobsWaitingInQueue() *gomock.Call {
 }
 
 // NewJob mocks base method.
-func (m *MockScheduler) NewJob(arg0 gocron.JobDefinition, arg1 gocron.Task, arg2 ...gocron.JobOption) (gocron.Job, error) {
+func (m *MockScheduler) NewJob(arg0 v2.JobDefinition, arg1 v2.Task, arg2 ...v2.JobOption) (v2.Job, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "NewJob", varargs...)
-	ret0, _ := ret[0].(gocron.Job)
+	ret0, _ := ret[0].(v2.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -158,14 +160,14 @@ func (mr *MockSchedulerMockRecorder) StopJobs() *gomock.Call {
 }
 
 // Update mocks base method.
-func (m *MockScheduler) Update(arg0 uuid.UUID, arg1 gocron.JobDefinition, arg2 gocron.Task, arg3 ...gocron.JobOption) (gocron.Job, error) {
+func (m *MockScheduler) Update(arg0 uuid.UUID, arg1 v2.JobDefinition, arg2 v2.Task, arg3 ...v2.JobOption) (v2.Job, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Update", varargs...)
-	ret0, _ := ret[0].(gocron.Job)
+	ret0, _ := ret[0].(v2.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -112,6 +112,11 @@ type jobOutRequest struct {
 	outChan chan internalJob
 }
 
+type jobOutUpdateLockRequest struct {
+	id   uuid.UUID
+	lock Lock
+}
+
 type runJobRequest struct {
 	id      uuid.UUID
 	outChan chan error
@@ -136,12 +141,13 @@ func NewScheduler(options ...SchedulerOption) (Scheduler, error) {
 		logger:           &noOpLogger{},
 		clock:            clockwork.NewRealClock(),
 
-		jobsIn:                 make(chan jobIn),
-		jobsOutForRescheduling: make(chan uuid.UUID),
-		jobUpdateNextRuns:      make(chan uuid.UUID),
-		jobsOutCompleted:       make(chan uuid.UUID),
-		jobOutRequest:          make(chan jobOutRequest, 1000),
-		done:                   make(chan error, 1),
+		jobsIn:                  make(chan jobIn),
+		jobsOutForRescheduling:  make(chan uuid.UUID),
+		jobUpdateNextRuns:       make(chan uuid.UUID),
+		jobsOutCompleted:        make(chan uuid.UUID),
+		jobOutRequest:           make(chan jobOutRequest, 1000),
+		jobOutUpdateLockRequest: make(chan jobOutUpdateLockRequest),
+		done:                    make(chan error, 1),
 	}
 
 	s := &scheduler{
@@ -196,6 +202,9 @@ func NewScheduler(options ...SchedulerOption) (Scheduler, error) {
 
 			case out := <-s.jobOutRequestCh:
 				s.selectJobOutRequest(out)
+
+			case out := <-s.exec.jobOutUpdateLockRequest:
+				s.jobOutUpdateLockRequest(out)
 
 			case out := <-s.allJobsOutRequest:
 				s.selectAllJobsOutRequest(out)
@@ -469,6 +478,13 @@ func (s *scheduler) selectJobOutRequest(out jobOutRequest) {
 		}
 	}
 	close(out.outChan)
+}
+
+func (s *scheduler) jobOutUpdateLockRequest(out jobOutUpdateLockRequest) {
+	if j, ok := s.jobs[out.id]; ok {
+		j.lastLock = out.lock
+		s.jobs[out.id] = j
+	}
 }
 
 func (s *scheduler) selectNewJob(in newJobIn) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -2828,3 +2828,45 @@ func TestScheduler_WithMonitor(t *testing.T) {
 		})
 	}
 }
+
+func TestJob_Lock(t *testing.T) {
+	locker := &testLocker{
+		notLocked: make(chan struct{}, 1),
+	}
+
+	s := newTestScheduler(t,
+		WithDistributedLocker(locker),
+	)
+
+	jobRan := make(chan struct{})
+	j, err := s.NewJob(
+		DurationJob(time.Millisecond*100),
+		NewTask(func() {
+			time.Sleep(50 * time.Millisecond)
+			jobRan <- struct{}{}
+		}),
+	)
+	require.NoError(t, err)
+
+	s.Start()
+	defer func(s Scheduler) {
+		err = s.Shutdown()
+		if err != nil {
+			require.NoError(t, err)
+		}
+	}(s)
+
+	select {
+	case <-jobRan:
+		// Job has run
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Job did not run in time")
+	}
+
+	require.Eventually(t, func() bool {
+		return locker.jobLocked
+	}, 200*time.Millisecond, 100*time.Millisecond, "Job should be locked")
+
+	lock := j.Lock()
+	assert.NotNil(t, lock, "Job Lock() should return a non-nil Locker")
+}


### PR DESCRIPTION
- Add `jobOutUpdateLockRequest` channel in the executor
- Implement lock update requests in the job execution process
- Add `Lock()` method to the `Job` interface
- Update the scheduler to handle lock update requests
- Add a test case to verify the new locking mechanism

This is a fixed version of #786

My focus has put me back on getting my past PR's I need merged :P.