### PR TITLE
a return is missing to stop execution if the job is not found

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -297,6 +297,7 @@ func (s *scheduler) selectRunJobRequest(run runJobRequest) {
 		case run.outChan <- ErrJobNotFound:
 		default:
 		}
+		return
 	}
 	select {
 	case <-s.shutdownCtx.Done():


### PR DESCRIPTION
### What does this do?
Added a return to the selectRunJobRequest function

### Have you included tests for your changes?
The existing tests remain, and they have passed

