### PR TITLE
fix: handle negative time.durations with error

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -14,6 +14,8 @@ var (
 	ErrDailyJobZeroInterval          = errors.New("gocron: DailyJob: interval must be greater than 0")
 	ErrDailyJobMinutesSeconds        = errors.New("gocron: DailyJob: atTimes minutes and seconds must be between 0 and 59 inclusive")
 	ErrDurationJobIntervalZero       = errors.New("gocron: DurationJob: time interval is 0")
+	ErrDurationJobIntervalNegative   = errors.New("gocron: DurationJob: time interval must be greater than 0")
+	ErrDurationRandomJobPositive     = errors.New("gocron: DurationRandomJob: minimum and maximum durations must be greater than 0")
 	ErrDurationRandomJobMinMax       = errors.New("gocron: DurationRandomJob: minimum duration must be less than maximum duration")
 	ErrEventListenerFuncNil          = errors.New("gocron: eventListenerFunc must not be nil")
 	ErrJobNotFound                   = errors.New("gocron: job not found")

--- a/job.go
+++ b/job.go
@@ -225,6 +225,9 @@ func (d durationJobDefinition) setup(j *internalJob, _ *time.Location, _ time.Ti
 	if d.duration == 0 {
 		return ErrDurationJobIntervalZero
 	}
+	if d.duration < 0 {
+		return ErrDurationJobIntervalNegative
+	}
 	j.jobSchedule = &durationJob{duration: d.duration}
 	return nil
 }
@@ -246,6 +249,10 @@ type durationRandomJobDefinition struct {
 func (d durationRandomJobDefinition) setup(j *internalJob, _ *time.Location, _ time.Time) error {
 	if d.min >= d.max {
 		return ErrDurationRandomJobMinMax
+	}
+
+	if d.min <= 0 || d.max <= 0 {
+		return ErrDurationRandomJobPositive
 	}
 
 	j.jobSchedule = &durationRandomJob{

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -705,6 +705,12 @@ func TestScheduler_NewJobErrors(t *testing.T) {
 			ErrDurationJobIntervalZero,
 		},
 		{
+			"duration job time interval is negative",
+			DurationJob(-1 * time.Second),
+			nil,
+			ErrDurationJobIntervalNegative,
+		},
+		{
 			"random with bad min/max",
 			DurationRandomJob(
 				time.Second*5,
@@ -712,6 +718,24 @@ func TestScheduler_NewJobErrors(t *testing.T) {
 			),
 			nil,
 			ErrDurationRandomJobMinMax,
+		},
+		{
+			"random with negative min",
+			DurationRandomJob(
+				-time.Second,
+				time.Second,
+			),
+			nil,
+			ErrDurationRandomJobPositive,
+		},
+		{
+			"random with negative max",
+			DurationRandomJob(
+				-2*time.Second,
+				-time.Second,
+			),
+			nil,
+			ErrDurationRandomJobPositive,
 		},
 		{
 			"daily job at times nil",


### PR DESCRIPTION
### What does this do?
properly handles negative time.Duration in Duration and DurationRandom jobs by returning an error

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->
resolves: #877 

### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
