### PR TITLE
fix: limit validation for WithLimitedRuns

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -59,6 +59,7 @@ var (
 	ErrStartTimeLaterThanEndTime     = errors.New("gocron: WithStartDateTime: start must not be later than end")
 	ErrStopTimeEarlierThanStartTime  = errors.New("gocron: WithStopDateTime: end must not be earlier than start")
 	ErrWithStopTimeoutZeroOrNegative = errors.New("gocron: WithStopTimeout: timeout must be greater than 0")
+	ErrWithLimitedRunsZero           = errors.New("gocron: WithLimitedRuns: limit must be greater than 0")
 )
 
 // internal errors

--- a/job.go
+++ b/job.go
@@ -643,6 +643,9 @@ func WithEventListeners(eventListeners ...EventListener) JobOption {
 // Upon reaching the limit, the job is removed from the scheduler.
 func WithLimitedRuns(limit uint) JobOption {
 	return func(j *internalJob, _ time.Time) error {
+		if limit == 0 {
+			return ErrWithLimitedRunsZero
+		}
 		j.limitRunsTo = &limitRunsTo{
 			limit:    limit,
 			runCount: 0,

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1056,6 +1056,14 @@ func TestScheduler_NewJobErrors(t *testing.T) {
 			[]JobOption{WithIdentifier(uuid.Nil)},
 			ErrWithIdentifierNil,
 		},
+		{
+			"WithLimitedRuns is zero",
+			DurationJob(
+				time.Second,
+			),
+			[]JobOption{WithLimitedRuns(0)},
+			ErrWithLimitedRunsZero,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this do?

Add limit validation for `WithLimitedRuns`

### Which issue(s) does this PR fix/relate to?
Resolves #892 

### List any changes that modify/break current functionality
- `WithLimitedRuns(0)` **previously created an unlimited job silently**  
- **Now returns an error** → job creation fails immediately  

**No breaking change for correct usage** (limit ≥ 1 unchanged)  
**Breaks only invalid config** (limit=0) — which was a silent bug before

### Have you included tests for your changes?
Yes

### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`
