### PR TITLE
feat: add ShutdownWithContext and StopJobsWithContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ func main() {
 
 	// when you're done, shut it down
 	err = s.Shutdown()
+	// or for context-aware teardown: 
+	// err = s.ShutdownWithContext(ctx)
 	if err != nil {
 		// handle error
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -517,6 +517,15 @@ func ExampleScheduler_shutdown() {
 	defer func() { _ = s.Shutdown() }()
 }
 
+func ExampleScheduler_shutdownWithContext() {
+	s, _ := gocron.NewScheduler()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	defer func() { _ = s.ShutdownWithContext(ctx) }()
+}
+
 func ExampleScheduler_start() {
 	s, _ := gocron.NewScheduler()
 	defer func() { _ = s.Shutdown() }()
@@ -551,6 +560,28 @@ func ExampleScheduler_stopJobs() {
 	s.Start()
 
 	_ = s.StopJobs()
+}
+
+func ExampleScheduler_stopJobsWithContext() {
+	s, _ := gocron.NewScheduler()
+	defer func() { _ = s.Shutdown() }()
+
+	_, _ = s.NewJob(
+		gocron.CronJob(
+			"* * * * *",
+			false,
+		),
+		gocron.NewTask(
+			func() {},
+		),
+	)
+
+	s.Start()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_ = s.StopJobsWithContext(ctx)
 }
 
 func ExampleScheduler_update() {

--- a/mocks/scheduler.go
+++ b/mocks/scheduler.go
@@ -10,6 +10,7 @@
 package gocronmocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	v2 "github.com/go-co-op/gocron/v2"
@@ -133,6 +134,20 @@ func (mr *MockSchedulerMockRecorder) Shutdown() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockScheduler)(nil).Shutdown))
 }
 
+// ShutdownWithContext mocks base method.
+func (m *MockScheduler) ShutdownWithContext(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShutdownWithContext", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ShutdownWithContext indicates an expected call of ShutdownWithContext.
+func (mr *MockSchedulerMockRecorder) ShutdownWithContext(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShutdownWithContext", reflect.TypeOf((*MockScheduler)(nil).ShutdownWithContext), arg0)
+}
+
 // Start mocks base method.
 func (m *MockScheduler) Start() {
 	m.ctrl.T.Helper()
@@ -157,6 +172,20 @@ func (m *MockScheduler) StopJobs() error {
 func (mr *MockSchedulerMockRecorder) StopJobs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopJobs", reflect.TypeOf((*MockScheduler)(nil).StopJobs))
+}
+
+// StopJobsWithContext mocks base method.
+func (m *MockScheduler) StopJobsWithContext(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StopJobsWithContext", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StopJobsWithContext indicates an expected call of StopJobsWithContext.
+func (mr *MockSchedulerMockRecorder) StopJobsWithContext(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopJobsWithContext", reflect.TypeOf((*MockScheduler)(nil).StopJobsWithContext), arg0)
 }
 
 // Update mocks base method.

--- a/scheduler.go
+++ b/scheduler.go
@@ -3,6 +3,7 @@ package gocron
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"runtime"
 	"slices"
@@ -38,6 +39,8 @@ type Scheduler interface {
 	// to a Close or Cleanup method and is often deferred after
 	// starting the scheduler.
 	Shutdown() error
+	// ShutdownWithContext behaves like Shutdown but respects the provided context's deadline.
+	ShutdownWithContext(context.Context) error
 	// Start begins scheduling jobs for execution based
 	// on each job's definition. Job's added to an already
 	// running scheduler will be scheduled immediately based
@@ -47,6 +50,8 @@ type Scheduler interface {
 	// This can be useful in situations where jobs need to be
 	// paused globally and then restarted with Start().
 	StopJobs() error
+	// StopJobsWithContext behaves like StopJobs but respects the provided context's deadline.
+	StopJobsWithContext(context.Context) error
 	// Update replaces the existing Job's JobDefinition with the provided
 	// JobDefinition. The Job's Job.ID() remains the same.
 	Update(uuid.UUID, JobDefinition, Task, ...JobOption) (Job, error)
@@ -860,23 +865,45 @@ func (s *scheduler) Start() {
 }
 
 func (s *scheduler) StopJobs() error {
+	ctx, cancel := context.WithTimeout(context.Background(), s.exec.stopTimeout+2*time.Second)
+	defer cancel()
+
+	err := s.StopJobsWithContext(ctx)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrStopSchedulerTimedOut
+	}
+	return err
+}
+
+func (s *scheduler) StopJobsWithContext(ctx context.Context) error {
 	select {
 	case <-s.shutdownCtx.Done():
 		return nil
 	case s.stopCh <- struct{}{}:
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 
-	t := time.NewTimer(s.exec.stopTimeout + 2*time.Second)
 	select {
 	case err := <-s.stopErrCh:
-		t.Stop()
 		return err
-	case <-t.C:
-		return ErrStopSchedulerTimedOut
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
 func (s *scheduler) Shutdown() error {
+	ctx, cancel := context.WithTimeout(context.Background(), s.exec.stopTimeout+2*time.Second)
+	defer cancel()
+
+	err := s.ShutdownWithContext(ctx)
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrStopSchedulerTimedOut
+	}
+	return err
+}
+
+func (s *scheduler) ShutdownWithContext(ctx context.Context) error {
 	s.logger.Debug("scheduler shutting down")
 
 	s.shutdownCancel()
@@ -884,16 +911,13 @@ func (s *scheduler) Shutdown() error {
 		return nil
 	}
 
-	t := time.NewTimer(s.exec.stopTimeout + 2*time.Second)
 	select {
 	case err := <-s.stopErrCh:
-		t.Stop()
-
 		// notify monitor that scheduler stopped
 		s.notifySchedulerShutdown()
 		return err
-	case <-t.C:
-		return ErrStopSchedulerTimedOut
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -578,6 +578,66 @@ func TestScheduler_Shutdown(t *testing.T) {
 	})
 }
 
+func TestScheduler_ShutdownWithContext(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	t.Run("clean shutdown completes before context deadline", func(t *testing.T) {
+		s := newTestScheduler(t, WithStopTimeout(time.Second))
+
+		s.Start()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+
+		require.NoError(t, s.ShutdownWithContext(ctx))
+	})
+
+	t.Run("shutdown times out if jobs block longer than context deadline", func(t *testing.T) {
+		s := newTestScheduler(t, WithStopTimeout(time.Second))
+
+		testCtx, testCancel := context.WithCancel(context.Background())
+		defer testCancel()
+
+		_, err := s.NewJob(
+			DurationJob(10*time.Millisecond),
+			NewTask(func() {
+				<-testCtx.Done() // Block job intentionally
+			}),
+			WithStartAt(WithStartImmediately()),
+		)
+		require.NoError(t, err)
+
+		s.Start()
+		time.Sleep(50 * time.Millisecond) // Let job start
+
+		// We give 50ms for shutdown context, this should timeout because the job is blocking until testCtx is done
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		err = s.ShutdownWithContext(ctx)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+
+		testCancel() // Unblock job so test can clean up gracefully
+		time.Sleep(50 * time.Millisecond)
+	})
+}
+
+func TestScheduler_StopJobsWithContext(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	t.Run("clean stop completes before context deadline", func(t *testing.T) {
+		s := newTestScheduler(t, WithStopTimeout(time.Second))
+
+		s.Start()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+
+		require.NoError(t, s.StopJobsWithContext(ctx))
+		require.NoError(t, s.Shutdown()) // clean up
+	})
+}
+
 func TestScheduler_Start(t *testing.T) {
 	defer verifyNoGoroutineLeaks(t)
 


### PR DESCRIPTION
### What does this do?
Adds `ShutdownWithContext` and `StopJobsWithContext` to allow shutting down the scheduler with a standard `context.Context`.

### Which issue(s) does this PR fix/relate to?
N/A

### List any changes that modify/break current functionality
- `Shutdown` and `StopJobs` now just call the new context methods under the hood using `context.WithTimeout`. Their old timeout behavior and errors remain exactly the same.
- Added the 2 new methods to the `Scheduler` interface.

### Have you included tests for your changes?
Yes, added tests in `scheduler_test.go` checking both clean shutdowns and context timeout errors. 

### Did you document any new/modified functionality?

- [x] Updated `example_test.go`
- [x] Updated `README.md`