### PR TITLE
perf: replace string allocation with bytes.Compare in Jobs() UUID sort

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -2,12 +2,12 @@
 package gocron
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"reflect"
 	"runtime"
 	"slices"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -295,8 +295,8 @@ func (s *scheduler) selectAllJobsOutRequest(out allJobsOutRequest) {
 		counter++
 	}
 	slices.SortFunc(outJobs, func(a, b Job) int {
-		aID, bID := a.ID().String(), b.ID().String()
-		return strings.Compare(aID, bID)
+		aID, bID := a.ID(), b.ID()
+		return bytes.Compare(aID[:], bID[:])
 	})
 	select {
 	case <-s.shutdownCtx.Done():

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3002,3 +3002,35 @@ func TestScheduler_WithStartAtDateTimePast(t *testing.T) {
 	// which was in the past Dec 31, 2023, so the next is Jan 7, 2024
 	assert.Equal(t, time.Date(2024, time.January, 7, 10, 0, 0, 0, time.UTC), nextRun)
 }
+
+func BenchmarkSchedulerJobs(b *testing.B) {
+	cases := []struct {
+		name string
+		n    int
+	}{
+		{"10", 10},
+		{"100", 100},
+		{"500", 500},
+	}
+	for _, tc := range cases {
+		tc := tc
+		b.Run(tc.name, func(b *testing.B) {
+			s, err := NewScheduler(WithLogger(NewLogger(LogLevelError)))
+			if err != nil {
+				b.Fatal(err)
+			}
+			for i := 0; i < tc.n; i++ {
+				_, err := s.NewJob(DurationJob(time.Hour), NewTask(func() {}))
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+			s.Start()
+			b.Cleanup(func() { _ = s.Shutdown() })
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = s.Jobs()
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this do?

`Jobs()` sorts results by UUID before returning. The comparator was calling `uuid.UUID.String()` on both sides, allocating two strings per comparison. Since `uuid.UUID` is `[16]byte`, we can compare raw bytes directly.

### Which issue(s) does this PR fix/relate to?
N/A

### List any changes that modify/break current functionality
None.

## Benchmark
```
goos: darwin
goarch: arm64
cpu: Apple M1

name                    old time/op      new time/op    delta
SchedulerJobs/10-8       4745 ns/op       2848 ns/op     -40%
SchedulerJobs/100-8     67616 ns/op      19742 ns/op     -71%
SchedulerJobs/500-8    435554 ns/op     104137 ns/op     -76%

name                  old allocs/op    new allocs/op    delta
SchedulerJobs/10-8               71               12     -83%
SchedulerJobs/100-8            1431              102     -93%
SchedulerJobs/500-8            9723              502     -95%

name                       old B/op         new B/op    delta
SchedulerJobs/10-8           3887 B           1072 B     -72%
SchedulerJobs/100-8         73725 B           9904 B     -87%
SchedulerJobs/500-8        490939 B          48304 B     -90%
```

### Have you included tests for your changes?
Existing `TestScheduler_Jobs/order_is_equal` covers sort correctness.
Added `BenchmarkSchedulerJobs` in `scheduler_test.go`.

### Did you document any new/modified functionality?
No API change.