### PR TITLE
fix: defer WithLimitedRuns job removal until task completes (#925)

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -487,17 +487,14 @@ func (s *scheduler) selectExecJobsOutCompleted(id uuid.UUID) {
 
 	// if the job has a limited number of runs set, we need to
 	// check how many runs have occurred and stop running this
-	// job if it has reached the limit.
+	// job if it has reached the limit. Removal is deferred until
+	// the task function actually completes (signaled via a non-zero
+	// completedAt on jobTimingUpdateCh) so that the job's context is
+	// not canceled while the task is still executing. See #925.
 	if j.limitRunsTo != nil {
 		j.limitRunsTo.runCount = j.limitRunsTo.runCount + 1
-		if j.limitRunsTo.runCount == j.limitRunsTo.limit {
-			go func() {
-				select {
-				case <-s.shutdownCtx.Done():
-					return
-				case s.removeJobCh <- id:
-				}
-			}()
+		if j.limitRunsTo.runCount >= j.limitRunsTo.limit {
+			s.jobs[id] = j
 			return
 		}
 	}
@@ -518,6 +515,20 @@ func (s *scheduler) selectJobTimingUpdate(update jobTimingUpdate) {
 		j.lastRunCompletedAt = update.completedAt
 	}
 	s.jobs[update.id] = j
+
+	// If the job has hit its WithLimitedRuns limit and the task function
+	// has finished (completedAt is set), remove the job now. This is done
+	// here rather than in selectExecJobsOutCompleted to avoid canceling
+	// the job's context while the task is still running. See #925.
+	if !update.completedAt.IsZero() && j.limitRunsTo != nil && j.limitRunsTo.runCount >= j.limitRunsTo.limit {
+		go func(id uuid.UUID) {
+			select {
+			case <-s.shutdownCtx.Done():
+				return
+			case s.removeJobCh <- id:
+			}
+		}(update.id)
+	}
 }
 
 func (s *scheduler) selectJobOutRequest(out *jobOutRequest) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3263,3 +3263,38 @@ func TestScheduler_WithStopDateTime_JobRemovedAfterStopTime(t *testing.T) {
 		require.NoError(t, s.Shutdown())
 	})
 }
+
+// TestScheduler_WithLimitedRuns_ContextNotCanceledDuringTask asserts that the
+// context passed to a task running under WithLimitedRuns is not canceled
+// while the task function is still executing. Regression test for #925.
+func TestScheduler_WithLimitedRuns_ContextNotCanceledDuringTask(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	s := newTestScheduler(t)
+
+	ctxErrCh := make(chan error, 1)
+	_, err := s.NewJob(
+		DurationJob(time.Hour),
+		NewTask(func(ctx context.Context) {
+			// Hold the task open briefly so the scheduler has time to
+			// process the after-rescheduling signal and (incorrectly)
+			// cancel the context before this function returns.
+			time.Sleep(100 * time.Millisecond)
+			ctxErrCh <- ctx.Err()
+		}),
+		WithStartAt(WithStartImmediately()),
+		WithLimitedRuns(1),
+	)
+	require.NoError(t, err)
+
+	s.Start()
+
+	select {
+	case ctxErr := <-ctxErrCh:
+		require.NoError(t, ctxErr, "task context must not be canceled while task is still running")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for task to run")
+	}
+
+	require.NoError(t, s.Shutdown())
+}


### PR DESCRIPTION
Fixes #925.

When a job is configured with `WithLimitedRuns` and reaches its run limit, the scheduler immediately removes the job, which cancels the context passed to the task. Because `selectExecJobsOutCompleted` runs before the user-supplied function executes in `runJob`, the task observed an already-canceled context.

The fix defers the actual `removeJobCh` send to `selectJobTimingUpdate` once it receives the `completedAt` update emitted after the task function returns. `runCount` is still incremented in `selectExecJobsOutCompleted` (no behavior change there); only the removal is delayed.

Added a regression test (`TestScheduler_WithLimitedRuns_ContextNotCanceledDuringTask`) that fails on `v2` and passes with this patch. `make test` (`go test -race -count=1 ./...`) passes cleanly.