### PR TITLE
fixes: internal job func call handles param len mismatch, and global job options supports multiple calls

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrDurationRandomJobMinMax       = errors.New("gocron: DurationRandomJob: minimum duration must be less than maximum duration")
 	ErrEventListenerFuncNil          = errors.New("gocron: eventListenerFunc must not be nil")
 	ErrJobNotFound                   = errors.New("gocron: job not found")
+	ErrJobParameterMismatch          = errors.New("gocron: job function called with wrong number of parameters")
 	ErrJobRunNowFailed               = errors.New("gocron: Job: RunNow: scheduler unreachable")
 	ErrMonthlyJobDays                = errors.New("gocron: MonthlyJob: daysOfTheMonth must be between 31 and -31 inclusive, and not 0")
 	ErrMonthlyJobAtTimeNil           = errors.New("gocron: MonthlyJob: atTime within atTimes must not be nil")

--- a/executor.go
+++ b/executor.go
@@ -418,6 +418,11 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	} else if !j.disabledLocker && j.locker != nil {
 		lock, err := j.locker.Lock(j.ctx, j.name)
 		if err != nil {
+			// Event-listener signatures are enforced by the typed JobOption
+			// factories (AfterLockError, BeforeJobRuns, etc.), so
+			// callJobFuncWithParams cannot return ErrJobParameterMismatch here
+			// in practice. We discard the error to keep listener execution
+			// best-effort. This applies to every listener call in this file.
 			_ = callJobFuncWithParams(j.afterLockError, j.id, j.name, err)
 			e.sendOutForRescheduling(&jIn)
 			e.incrementJobCounter(j, Skip)

--- a/scheduler.go
+++ b/scheduler.go
@@ -1103,9 +1103,12 @@ func WithDistributedLocker(locker Locker) SchedulerOption {
 // WithGlobalJobOptions sets JobOption's that will be applied to
 // all jobs added to the scheduler. JobOption's set on the job
 // itself will override if the same JobOption is set globally.
+//
+// WithGlobalJobOptions may be called multiple times; options from all
+// calls are appended in order and applied to each job in that order.
 func WithGlobalJobOptions(jobOptions ...JobOption) SchedulerOption {
 	return func(s *scheduler) error {
-		s.globalJobOptions = jobOptions
+		s.globalJobOptions = append(s.globalJobOptions, jobOptions...)
 		return nil
 	}
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3352,3 +3352,32 @@ func TestScheduler_CronWithZeroNext_DoesNotHang(t *testing.T) {
 		t.Fatal("scheduler hung when custom Cron.Next returned zero time")
 	}
 }
+
+// TestScheduler_WithGlobalJobOptions_MultipleCallsAppend asserts that
+// passing WithGlobalJobOptions multiple times to NewScheduler results
+// in all option lists being applied to each job (in order), rather
+// than the last call silently overwriting earlier calls. See H6 in
+// CODE_REVIEW.md.
+func TestScheduler_WithGlobalJobOptions_MultipleCallsAppend(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	s := newTestScheduler(t,
+		WithGlobalJobOptions(WithTags("shared-tag")),
+		WithGlobalJobOptions(WithName("shared-name")),
+	)
+
+	j, err := s.NewJob(
+		DurationJob(time.Hour),
+		NewTask(func() {}),
+	)
+	require.NoError(t, err)
+
+	// Both option lists must have applied. If WithGlobalJobOptions
+	// had overwritten instead of appended, only the "shared-name"
+	// option (from the second call) would be present and Tags()
+	// would be empty.
+	require.Equal(t, []string{"shared-tag"}, j.Tags())
+	require.Equal(t, "shared-name", j.Name())
+
+	require.NoError(t, s.Shutdown())
+}

--- a/util.go
+++ b/util.go
@@ -19,7 +19,7 @@ func callJobFuncWithParams(jobFunc any, params ...any) error {
 		return nil
 	}
 	if len(params) != f.Type().NumIn() {
-		return nil
+		return ErrJobParameterMismatch
 	}
 	in := make([]reflect.Value, len(params))
 	for k, param := range params {

--- a/util_test.go
+++ b/util_test.go
@@ -59,7 +59,7 @@ func TestCallJobFuncWithParams(t *testing.T) {
 			"wrong number of params",
 			func(_ string, _ int) {},
 			[]any{"one"},
-			nil,
+			ErrJobParameterMismatch,
 		},
 		{
 			"function that returns an error",


### PR DESCRIPTION
### What does this do?

**feat(errors): return ErrJobParameterMismatch on arity mismatch**

callJobFuncWithParams previously returned nil when the number of  parameters did not match the function's expected arity, silently no-op'ing the call. User task functions are validated at registration by (*scheduler).verifyParameterType and event-listener signatures are enforced by their typed JobOption factories, so this path is not reachable through the public API today. Returning an explicit sentinel error makes any future regression loud rather than silent. The user-task path already surfaces the error through the scheduler monitor and the afterJobRunsWithError listener.

**fix(scheduler): WithGlobalJobOptions appends across multiple calls**

WithGlobalJobOptions previously assigned the incoming options directly to scheduler.globalJobOptions, so calling it more than once during NewScheduler(...) silently dropped every prior call. This turns a surprising footgun into intuitive composition without changing behavior for callers that only invoke the option once.

Regression test constructs a scheduler with two WithGlobalJobOptions calls (one setting a tag, one setting a name), creates a job, and asserts both effects are present on the resulting Job — proving both option lists were applied rather than the second overwriting the first.


### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
