### PR TITLE
fix(scheduler): skipped runs no longer consume WithLimitedRuns budget

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -27,7 +27,7 @@ type executor struct {
 	// sends out jobs for rescheduling
 	jobsOutForRescheduling chan uuid.UUID
 	// sends out jobs once completed
-	jobsOutCompleted chan uuid.UUID
+	jobsOutCompleted chan jobOutCompleted
 	// used to request jobs from the scheduler
 	jobOutRequest chan *jobOutRequest
 
@@ -66,6 +66,17 @@ type jobTimingUpdate struct {
 	id          uuid.UUID
 	startedAt   time.Time
 	completedAt time.Time
+}
+
+// jobOutCompleted signals that a scheduled invocation of a job has
+// reached its completion point in the executor. skipped is true when
+// the run was aborted before the task function ran (for example, by
+// BeforeJobRunsSkipIfBeforeFuncErrors); the scheduler uses this to
+// avoid consuming a WithLimitedRuns slot for a run that never
+// actually executed.
+type jobOutCompleted struct {
+	id      uuid.UUID
+	skipped bool
 }
 
 type jobIn struct {
@@ -459,7 +470,7 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	if err != nil {
 		e.sendOutForRescheduling(&jIn)
 		select {
-		case e.jobsOutCompleted <- j.id:
+		case e.jobsOutCompleted <- jobOutCompleted{id: j.id, skipped: true}:
 		case <-e.ctx.Done():
 		}
 		// Notify job failed (before actual run)
@@ -479,7 +490,7 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	if !j.intervalFromCompletion {
 		e.sendOutForRescheduling(&jIn)
 		select {
-		case e.jobsOutCompleted <- j.id:
+		case e.jobsOutCompleted <- jobOutCompleted{id: j.id}:
 		case <-e.ctx.Done():
 		}
 	}
@@ -530,7 +541,7 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	// For intervalFromCompletion, reschedule AFTER the job completes
 	if j.intervalFromCompletion {
 		select {
-		case e.jobsOutCompleted <- j.id:
+		case e.jobsOutCompleted <- jobOutCompleted{id: j.id}:
 		case <-e.ctx.Done():
 		}
 		e.sendOutForRescheduling(&jIn)

--- a/scheduler.go
+++ b/scheduler.go
@@ -148,7 +148,7 @@ func NewScheduler(options ...SchedulerOption) (Scheduler, error) {
 		jobsIn:                 make(chan jobIn),
 		jobsOutForRescheduling: make(chan uuid.UUID),
 		jobUpdateNextRuns:      make(chan uuid.UUID),
-		jobsOutCompleted:       make(chan uuid.UUID),
+		jobsOutCompleted:       make(chan jobOutCompleted),
 		jobOutRequest:          make(chan *jobOutRequest, 100),
 		done:                   make(chan error, 1),
 		jobTimingUpdateCh:      make(chan jobTimingUpdate, 100),
@@ -190,8 +190,8 @@ func NewScheduler(options ...SchedulerOption) (Scheduler, error) {
 				s.selectExecJobsOutForRescheduling(id)
 			case id := <-s.exec.jobUpdateNextRuns:
 				s.updateNextScheduled(id)
-			case id := <-s.exec.jobsOutCompleted:
-				s.selectExecJobsOutCompleted(id)
+			case completed := <-s.exec.jobsOutCompleted:
+				s.selectExecJobsOutCompleted(completed)
 
 			case update := <-s.exec.jobTimingUpdateCh:
 				s.selectJobTimingUpdate(update)
@@ -487,8 +487,8 @@ func (s *scheduler) updateNextScheduled(id uuid.UUID) {
 	s.jobs[id] = j
 }
 
-func (s *scheduler) selectExecJobsOutCompleted(id uuid.UUID) {
-	j, ok := s.jobs[id]
+func (s *scheduler) selectExecJobsOutCompleted(completed jobOutCompleted) {
+	j, ok := s.jobs[completed.id]
 	if !ok {
 		return
 	}
@@ -504,6 +504,14 @@ func (s *scheduler) selectExecJobsOutCompleted(id uuid.UUID) {
 	}
 	j.nextScheduled = newNextScheduled
 
+	// Skipped runs (for example, when BeforeJobRunsSkipIfBeforeFuncErrors
+	// returns an error) don't consume a WithLimitedRuns slot and don't
+	// update lastRun — the task function never executed.
+	if completed.skipped {
+		s.jobs[completed.id] = j
+		return
+	}
+
 	// if the job has a limited number of runs set, we need to
 	// check how many runs have occurred and stop running this
 	// job if it has reached the limit. Removal is deferred until
@@ -513,13 +521,13 @@ func (s *scheduler) selectExecJobsOutCompleted(id uuid.UUID) {
 	if j.limitRunsTo != nil {
 		j.limitRunsTo.runCount = j.limitRunsTo.runCount + 1
 		if j.limitRunsTo.runCount >= j.limitRunsTo.limit {
-			s.jobs[id] = j
+			s.jobs[completed.id] = j
 			return
 		}
 	}
 
 	j.lastRun = s.now()
-	s.jobs[id] = j
+	s.jobs[completed.id] = j
 }
 
 func (s *scheduler) selectJobTimingUpdate(update jobTimingUpdate) {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3381,3 +3381,47 @@ func TestScheduler_WithGlobalJobOptions_MultipleCallsAppend(t *testing.T) {
 
 	require.NoError(t, s.Shutdown())
 }
+
+// TestScheduler_WithLimitedRuns_SkippedRunsDoNotConsumeBudget asserts
+// that runs aborted before the task function executes (for example,
+// by BeforeJobRunsSkipIfBeforeFuncErrors returning an error) do not
+// count against the WithLimitedRuns budget. See C3 in CODE_REVIEW.md.
+func TestScheduler_WithLimitedRuns_SkippedRunsDoNotConsumeBudget(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	s := newTestScheduler(t)
+
+	var skipCalls atomic.Int32
+	var runs atomic.Int32
+	const forcedSkips = 3
+
+	_, err := s.NewJob(
+		DurationJob(20*time.Millisecond),
+		NewTask(func() { runs.Add(1) }),
+		WithStartAt(WithStartImmediately()),
+		WithLimitedRuns(2),
+		WithEventListeners(
+			BeforeJobRunsSkipIfBeforeFuncErrors(func(_ uuid.UUID, _ string) error {
+				// Force the first `forcedSkips` invocations to skip;
+				// afterward let the task run.
+				if skipCalls.Add(1) <= forcedSkips {
+					return errors.New("forced skip")
+				}
+				return nil
+			}),
+		),
+	)
+	require.NoError(t, err)
+
+	s.Start()
+	// Wait long enough for forcedSkips skips + 2 real runs at 20ms
+	// intervals to play out with margin for CI noise.
+	time.Sleep(400 * time.Millisecond)
+	require.NoError(t, s.Shutdown())
+
+	require.GreaterOrEqual(t, skipCalls.Load(), int32(forcedSkips),
+		"beforeFunc should have fired at least forcedSkips times")
+	require.Equal(t, int32(2), runs.Load(),
+		"task should have executed exactly WithLimitedRuns(2) times, "+
+			"regardless of how many prior invocations were skipped")
+}


### PR DESCRIPTION
### What does this do?

When `BeforeJobRunsSkipIfBeforeFuncErrors` returned an error, the executor still signaled the run as completed on `jobsOutCompleted`, and the scheduler unconditionally incremented `limitRunsTo.runCount` for every such signal. A job configured with `WithLimitedRuns(N)` plus a beforeFunc that occasionally errors would therefore be removed after N scheduled attempts even if the user's task function never ran, violating the 'limits the number of executions' contract on `WithLimitedRuns`.

The channel now carries a `jobOutCompleted{id, skipped}` struct instead of a bare `uuid.UUID` (mirroring the `jobTimingUpdate` pattern). The three send sites in `runJob` tag themselves:
  - skip-before-run path: skipped=true
  - normal path (pre-run): skipped=false
  - intervalFromCompletion path (post-run): skipped=false

`selectExecJobsOutCompleted` still prunes `nextScheduled` on both paths (the scheduled time is behind us regardless of whether the task ran) but returns early before touching `runCount` or `lastRun` when skipped is true.

Regression test `TestScheduler_WithLimitedRuns_SkippedRunsDoNotConsumeBudget` configures `WithLimitedRuns(2)` with a `beforeFunc` that errors on the first 3 invocations and asserts the task function executes exactly 2 times. The test was verified to fail against the pre-fix behavior (only 1 execution, since the 3 skips consumed 3 of the 2 slots).

### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
