### PR TITLE
refactor(scheduler): make nextScheduled ascending-time invariant explicit

### DIFF
--- a/job.go
+++ b/job.go
@@ -51,8 +51,14 @@ type internalJob struct {
 	jobSchedule
 	daylightSavingsTimePolicy DaylightSavingsTimePolicy
 
-	// as some jobs may queue up, it's possible to
-	// have multiple nextScheduled times
+	// nextScheduled holds upcoming scheduled invocation times for the
+	// job. Ordered ascending by wall-clock instant (see ascendingTime).
+	// Job.NextRun and Job.NextRuns rely on this invariant. All
+	// mutations must go through insertNextScheduled or the filter
+	// helpers in the scheduler; do NOT append directly.
+	//
+	// As some jobs may queue up, it's possible to have multiple
+	// nextScheduled times.
 	nextScheduled []time.Time
 
 	lastRun                time.Time

--- a/scheduler.go
+++ b/scheduler.go
@@ -433,11 +433,11 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		}
 	}
 
-	if slices.Contains(j.nextScheduled, next) {
+	if nextScheduledContains(j.nextScheduled, next) {
 		// if the next value is a duplicate of what's already in the nextScheduled slice, for example:
 		// - the job is being rescheduled off the same next run value as before
 		// increment to the next, next value
-		for slices.Contains(j.nextScheduled, next) {
+		for nextScheduledContains(j.nextScheduled, next) {
 			next = j.next(next)
 		}
 	}
@@ -453,7 +453,7 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		j.timer = nil // Ensure timer is cleared for GC
 	}
 
-	j.nextScheduled = append(j.nextScheduled, next)
+	j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
 	j.timer = s.exec.clock.AfterFunc(next.Sub(s.now()), func() {
 		// set the actual timer on the job here and listen for
 		// shut down events so that the job doesn't attempt to
@@ -616,7 +616,7 @@ func (s *scheduler) selectNewJob(in newJobIn) {
 			})
 		}
 		j.startTime = next
-		j.nextScheduled = append(j.nextScheduled, next)
+		j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
 	}
 
 	s.jobs[j.id] = j
@@ -685,7 +685,7 @@ func (s *scheduler) selectStart() {
 			})
 		}
 		j.startTime = next
-		j.nextScheduled = append(j.nextScheduled, next)
+		j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
 		s.jobs[id] = j
 	}
 	select {

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3425,3 +3425,41 @@ func TestScheduler_WithLimitedRuns_SkippedRunsDoNotConsumeBudget(t *testing.T) {
 		"task should have executed exactly WithLimitedRuns(2) times, "+
 			"regardless of how many prior invocations were skipped")
 }
+
+// TestScheduler_NextRuns_ReturnsAscendingAfterRescheduleCycles asserts
+// that after many reschedule cycles, Job.NextRuns returns strictly
+// ascending times. This locks in the internalJob.nextScheduled
+// sort invariant that NextRun/NextRuns rely on (job.go:1614/1627/1633).
+// See H4 in CODE_REVIEW.md.
+func TestScheduler_NextRuns_ReturnsAscendingAfterRescheduleCycles(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	s := newTestScheduler(t)
+	j, err := s.NewJob(
+		DurationJob(15*time.Millisecond),
+		NewTask(func() {}),
+		WithStartAt(WithStartImmediately()),
+	)
+	require.NoError(t, err)
+
+	s.Start()
+
+	// Poll NextRuns while the scheduler cycles the job.
+	deadline := time.Now().Add(300 * time.Millisecond)
+	checks := 0
+	for time.Now().Before(deadline) {
+		runs, err := j.NextRuns(5)
+		require.NoError(t, err)
+		for i := 1; i < len(runs); i++ {
+			require.False(t, runs[i].Before(runs[i-1]),
+				"NextRuns must return strictly ascending times: "+
+					"idx %d (%v) < idx %d (%v); full result: %v",
+				i, runs[i], i-1, runs[i-1], runs)
+		}
+		checks++
+		time.Sleep(5 * time.Millisecond)
+	}
+	require.Greater(t, checks, 10, "sanity: expected many polling iterations")
+
+	require.NoError(t, s.Shutdown())
+}

--- a/util.go
+++ b/util.go
@@ -91,6 +91,27 @@ func ascendingTime(a, b time.Time) int {
 	return a.Compare(b)
 }
 
+// insertNextScheduled inserts t into times while preserving the
+// ascending-time invariant that Job.NextRun and Job.NextRuns rely on.
+// The caller must ensure times is already sorted ascending; this is
+// enforced by construction because every mutation site goes through
+// this helper. Uses ascendingTime (time.Time.Compare) so ordering is
+// determined by wall-clock instant regardless of monotonic readings.
+func insertNextScheduled(times []time.Time, t time.Time) []time.Time {
+	idx, _ := slices.BinarySearchFunc(times, t, ascendingTime)
+	return slices.Insert(times, idx, t)
+}
+
+// nextScheduledContains reports whether times (sorted ascending)
+// contains a value at the same wall-clock instant as t, ignoring any
+// difference in monotonic readings. Callers relying on slices.Contains
+// would miss such matches because Go's == on time.Time also compares
+// monotonic components.
+func nextScheduledContains(times []time.Time, t time.Time) bool {
+	_, found := slices.BinarySearchFunc(times, t, ascendingTime)
+	return found
+}
+
 type waitGroupWithMutex struct {
 	wg sync.WaitGroup
 	mu sync.Mutex

--- a/util_test.go
+++ b/util_test.go
@@ -163,3 +163,96 @@ func TestConvertAtTimesToDateTime(t *testing.T) {
 		})
 	}
 }
+
+func TestInsertNextScheduled(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		start  []time.Time
+		insert time.Time
+		want   []time.Time
+	}{
+		{
+			name:   "empty slice",
+			start:  nil,
+			insert: base,
+			want:   []time.Time{base},
+		},
+		{
+			name:   "insert at start",
+			start:  []time.Time{base.Add(time.Hour), base.Add(2 * time.Hour)},
+			insert: base,
+			want:   []time.Time{base, base.Add(time.Hour), base.Add(2 * time.Hour)},
+		},
+		{
+			name:   "insert in middle",
+			start:  []time.Time{base, base.Add(2 * time.Hour)},
+			insert: base.Add(time.Hour),
+			want:   []time.Time{base, base.Add(time.Hour), base.Add(2 * time.Hour)},
+		},
+		{
+			name:   "insert at end",
+			start:  []time.Time{base, base.Add(time.Hour)},
+			insert: base.Add(2 * time.Hour),
+			want:   []time.Time{base, base.Add(time.Hour), base.Add(2 * time.Hour)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// make a defensive copy so table entries stay pristine across sub-tests
+			start := append([]time.Time(nil), tt.start...)
+			got := insertNextScheduled(start, tt.insert)
+			assert.Equal(t, tt.want, got)
+
+			// verify sorted invariant
+			for i := 1; i < len(got); i++ {
+				assert.False(t, got[i].Before(got[i-1]),
+					"result must be sorted ascending: idx %d (%v) < idx %d (%v)",
+					i, got[i], i-1, got[i-1])
+			}
+		})
+	}
+}
+
+func TestInsertNextScheduled_MonotonicVsWallClock(t *testing.T) {
+	// A time.Time from time.Now() carries a monotonic reading; the
+	// same instant reconstructed via time.Date does not. Go's ==
+	// operator considers these unequal, but ascendingTime (which
+	// uses time.Compare) treats them as equal instants. Confirm the
+	// helper places the "same instant" value adjacent to its twin
+	// rather than at the wrong end of the slice.
+	nowMonotonic := time.Now()
+	sameInstantNoMono := time.Unix(0, nowMonotonic.UnixNano()).In(nowMonotonic.Location())
+
+	got := insertNextScheduled([]time.Time{sameInstantNoMono}, nowMonotonic)
+	assert.Len(t, got, 2)
+	// both entries should represent the same wall-clock instant
+	assert.True(t, got[0].Equal(got[1]),
+		"the two entries should represent the same wall-clock instant")
+}
+
+func TestNextScheduledContains(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	slice := []time.Time{base, base.Add(time.Hour), base.Add(2 * time.Hour)}
+
+	assert.True(t, nextScheduledContains(slice, base))
+	assert.True(t, nextScheduledContains(slice, base.Add(time.Hour)))
+	assert.True(t, nextScheduledContains(slice, base.Add(2*time.Hour)))
+	assert.False(t, nextScheduledContains(slice, base.Add(30*time.Minute)))
+	assert.False(t, nextScheduledContains(nil, base))
+}
+
+func TestNextScheduledContains_MonotonicMismatch(t *testing.T) {
+	// slices.Contains uses ==, which compares monotonic readings.
+	// nextScheduledContains uses time.Compare via ascendingTime, so
+	// it correctly treats two representations of the same instant
+	// as a match. This is a correctness fix over the previous
+	// slices.Contains-based duplicate detection.
+	nowMonotonic := time.Now()
+	sameInstantNoMono := time.Unix(0, nowMonotonic.UnixNano()).In(nowMonotonic.Location())
+
+	assert.True(t, nextScheduledContains([]time.Time{sameInstantNoMono}, nowMonotonic),
+		"instants are equal per time.Compare; helper must report contains=true")
+}


### PR DESCRIPTION
### What does this do?
Job.NextRun (job.go:1614) and Job.NextRuns (job.go:1627, 1633) read internalJob.nextScheduled as if sorted ascending. The invariant was maintained implicitly by three properties that nothing in the code enforced:

  1. Fresh jobs start with an empty slice (via addOrUpdateJob resetting j := internalJob{}).
  2. All three append sites (scheduler.go:456, 619, 688) happened to append values that are chronologically >= any existing element.
  3. A defensive slices.SortStableFunc at scheduler.go:406 patched over any accidental disorder before it was observed by the rescheduler.

Nothing prevented a future edit from breaking (2). A new append site, or a caller pattern that mutates nextScheduled between filter and append, would silently produce wrong results from Job.NextRun and Job.NextRuns — with no test, no assertion, and no lint to catch it.

This change makes the invariant explicit:

  * New helper insertNextScheduled (util.go) does binary-search insertion using ascendingTime (time.Time.Compare), preserving the ascending-instant order regardless of monotonic-clock components.
  * All three append sites migrate to insertNextScheduled.
  * The nextScheduled field gets a docstring stating the invariant and mandating routing all mutations through the helper.
  * The defensive sort at scheduler.go:406 is intentionally kept as belt-and-suspenders; it's effectively free on typical length-1..2 slices and provides a second line of defense.

Correctness fix bundled in
-------------------------

The duplicate check at scheduler.go:436-441 used slices.Contains, which compares time.Time with Go's ==, including monotonic readings. Values in nextScheduled come from mixed sources: j.next() returns wall-clock- only times (cron.Schedule.Next() and friends) while s.now() on a real clock returns times with monotonic readings. Two logically-equal instants with different monotonic components compared as != under the old code, so the duplicate-advancement loop could fail to trigger for real collisions.

A companion helper nextScheduledContains (util.go) uses slices.BinarySearchFunc with ascendingTime, making duplicate detection wall-clock-based and correct across monotonic mismatches. The two call sites at scheduler.go:436, 440 migrate to it.

Verification
------------

  * Unit tests for insertNextScheduled and nextScheduledContains covering empty/start/middle/end insertions plus the monotonic-vs-wall-clock case that motivates the correctness fix.
  * Integration test TestScheduler_NextRuns_ReturnsAscendingAfterRescheduleCycles polls NextRuns while a duration job cycles and asserts strictly ascending results at each observation. This is defense-in-depth protection against future regressions; the current code (and the prior code) both pass it because the slice usually shrinks to length 1 between cycles, so the failure mode is masked in end-to-end tests. The unit tests are the primary regression guard.
  * Negative control: temporarily sabotaged insertNextScheduled to insert at index 0 unconditionally; unit tests fail immediately with a clear 'result must be sorted ascending' message, then restored.
  * Full suite passes with -race -count=1 in ~60s.
  * golangci-lint clean.

No exported types or function signatures change.




### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
