### PR TITLE
L-tier finale: typed LimitMode, docstrings, invariant comments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.4.0
+    rev: v2.11.4
     hooks:
       - id: golangci-lint
   - repo: https://github.com/TekWizely/pre-commit-golang

--- a/executor.go
+++ b/executor.go
@@ -300,6 +300,18 @@ func (e *executor) sendOutForNextRunUpdate(jIn *jobIn) {
 	}
 }
 
+// limitModeRunner is the worker goroutine spawned per limit-mode slot
+// under WithLimitConcurrentJobs. Multiple runners share the same `in`
+// channel (the limit-mode queue in scheduler.exec.limitMode), so the
+// number of runners bounds concurrent execution across ALL jobs.
+//
+// Behavior by mode:
+//   - LimitModeReschedule: a full queue causes the send in selectStart
+//     to non-block via rescheduleLimiter (cap == limit); overflow runs
+//     are dropped and the job is rescheduled at its next tick.
+//   - LimitModeWait: sends block on the queue, so callers wait for a
+//     slot rather than being dropped. See the LimitModeWait doc
+//     warning about queue growth.
 func (e *executor) limitModeRunner(name string, in chan jobIn, wg *waitGroupWithMutex, limitMode LimitMode, rescheduleLimiter chan struct{}) {
 	e.logger.Debug("gocron: limitModeRunner starting", "name", name)
 	for {
@@ -365,6 +377,14 @@ func (e *executor) limitModeRunner(name string, in chan jobIn, wg *waitGroupWith
 	}
 }
 
+// singletonModeRunner is the worker goroutine spawned per job that has
+// WithSingletonMode set. Unlike limitModeRunner, `in` is unique per
+// job (owned by e.singletonRunners[jobID]), so the runner serializes
+// runs of that ONE job while other jobs run freely.
+//
+// LimitModeReschedule drops overlapping ticks (job still executing);
+// LimitModeWait queues them up to the channel's buffer
+// (defaultSingletonQueueBuffer, see scheduler.go).
 func (e *executor) singletonModeRunner(name string, in chan jobIn, wg *waitGroupWithMutex, limitMode LimitMode, rescheduleLimiter chan struct{}) {
 	e.logger.Debug("gocron: singletonModeRunner starting", "name", name)
 	for {

--- a/job.go
+++ b/job.go
@@ -170,6 +170,16 @@ type limitRunsTo struct {
 // Cron defines the interface that must be
 // implemented to provide a custom cron implementation for
 // the job. Pass in the implementation using the JobOption WithCronImplementation.
+//
+// IsValid parses crontab and returns nil if it is a syntactically valid
+// expression with at least one future run relative to now. Implementations
+// SHOULD honor the location argument as the default timezone, but MAY be
+// overridden by an explicit timezone prefix on the crontab itself (see the
+// defaultCron.IsValid docstring for the precedence rules gocron ships with).
+//
+// Next returns the next scheduled run after lastRun. Callers assume the
+// returned time is strictly after lastRun; returning lastRun or an earlier
+// value can cause the scheduler to spin.
 type Cron interface {
 	IsValid(crontab string, location *time.Location, now time.Time) error
 	Next(lastRun time.Time) time.Time
@@ -211,6 +221,21 @@ type defaultCron struct {
 	withSeconds  bool
 }
 
+// IsValid parses crontab against the given location.
+//
+// Timezone precedence:
+//  1. If crontab starts with "TZ=" or "CRON_TZ=", that prefix wins and
+//     the location argument is ignored.
+//  2. Otherwise the location is prepended as "CRON_TZ=<location.String()>".
+//     location.String() is used verbatim (e.g. "UTC", "America/New_York",
+//     "Local"). Some platforms/locales may report location names that
+//     robfig/cron does not accept; callers who need portability should
+//     supply a standard IANA zone via WithLocation.
+//
+// Returns ErrCronJobParse (wrapping the parser's error) on syntactic
+// failure, or ErrCronJobInvalid when the crontab parses but produces
+// no future run relative to now (e.g. a one-shot expression already in
+// the past).
 func (c *defaultCron) IsValid(crontab string, location *time.Location, now time.Time) error {
 	var withLocation string
 	if strings.HasPrefix(crontab, "TZ=") || strings.HasPrefix(crontab, "CRON_TZ=") {

--- a/scheduler.go
+++ b/scheduler.go
@@ -335,6 +335,10 @@ func (s *scheduler) stopScheduler() {
 	s.notifySchedulerStopped()
 }
 
+// selectAllJobsOutRequest handles Scheduler.Jobs() calls. Snapshots the
+// current jobs map into an owned []Job and sends it on out.outChan. The
+// snapshot is sorted by raw UUID bytes; see Scheduler.Jobs() for the
+// ordering rationale.
 func (s *scheduler) selectAllJobsOutRequest(out allJobsOutRequest) {
 	outJobs := make([]Job, len(s.jobs))
 	var counter int
@@ -352,6 +356,11 @@ func (s *scheduler) selectAllJobsOutRequest(out allJobsOutRequest) {
 	}
 }
 
+// selectRunJobRequest handles Job.RunNow() calls. Forwards the job to
+// the executor's jobsIn channel and reports the outcome (or
+// ErrJobNotFound / shutdown) back on run.outChan. Waits on jobsIn
+// rather than dropping, so callers get accurate backpressure signal
+// bounded by defaultRunNowSendTimeout.
 func (s *scheduler) selectRunJobRequest(run runJobRequest) {
 	j, ok := s.jobs[run.id]
 	if !ok {
@@ -378,6 +387,8 @@ func (s *scheduler) selectRunJobRequest(run runJobRequest) {
 	}
 }
 
+// selectRemoveJob deletes a single job by id and cancels its running
+// context. No-op if the id is unknown.
 func (s *scheduler) selectRemoveJob(id uuid.UUID) {
 	j, ok := s.jobs[id]
 	if !ok {
@@ -407,8 +418,10 @@ func (s *scheduler) advancePastNow(j internalJob, next time.Time) (time.Time, bo
 	return next, true
 }
 
-// Jobs coming back from the executor to the scheduler that
-// need to be evaluated for rescheduling.
+// selectExecJobsOutForRescheduling handles the executor's post-run
+// notification for a job that just started. Advances j.nextRun past
+// now, updates the timer, and appends to nextScheduled. No-op if the
+// job was removed while running.
 func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 	select {
 	case <-s.shutdownCtx.Done():
@@ -524,6 +537,11 @@ func (s *scheduler) updateNextScheduled(id uuid.UUID) {
 	s.jobs[id] = j
 }
 
+// selectExecJobsOutCompleted handles the executor's post-run
+// notification for a completed run. Records lastRun, prunes past
+// entries from j.nextScheduled, and evaluates the WithLimitedRuns
+// stop condition. Runs that were skipped before execution do NOT
+// arrive here (see C3 in Plan #3).
 func (s *scheduler) selectExecJobsOutCompleted(completed jobOutCompleted) {
 	j, ok := s.jobs[completed.id]
 	if !ok {
@@ -560,6 +578,9 @@ func (s *scheduler) selectExecJobsOutCompleted(completed jobOutCompleted) {
 	s.jobs[completed.id] = j
 }
 
+// selectJobTimingUpdate applies a start/stop-time change to an
+// existing job while the scheduler is running, re-evaluating
+// nextRun so the change takes effect on the next tick.
 func (s *scheduler) selectJobTimingUpdate(update jobTimingUpdate) {
 	j, ok := s.jobs[update.id]
 	if !ok {
@@ -588,6 +609,11 @@ func (s *scheduler) selectJobTimingUpdate(update jobTimingUpdate) {
 	}
 }
 
+// selectJobOutRequest handles Job.X() accessor queries (LastRun,
+// NextRun, IsRunning, etc.). If the id is unknown the outChan is
+// closed WITHOUT a send, which requestJobCtx interprets as
+// ErrJobNotFound. A slow/absent receiver is bounded by the caller's
+// requestJob timeout (surfaced as ErrSchedulerBusy).
 func (s *scheduler) selectJobOutRequest(out *jobOutRequest) {
 	if j, ok := s.jobs[out.id]; ok {
 		select {
@@ -598,6 +624,10 @@ func (s *scheduler) selectJobOutRequest(out *jobOutRequest) {
 	close(out.outChan)
 }
 
+// selectNewJob installs a job produced by addOrUpdateJob into s.jobs.
+// Runs the job's initial nextRun computation and, if the scheduler is
+// already started, wires it into the executor immediately. Signals
+// completion via in.cancel() so NewJob can return.
 func (s *scheduler) selectNewJob(in newJobIn) {
 	j := in.job
 	if s.started.Load() {
@@ -653,6 +683,8 @@ func (s *scheduler) selectNewJob(in newJobIn) {
 	in.cancel()
 }
 
+// selectRemoveJobsByTags deletes every job whose tag set intersects
+// tags. Cancels each removed job's running context.
 func (s *scheduler) selectRemoveJobsByTags(tags []string) {
 	for _, j := range s.jobs {
 		for _, tag := range tags {
@@ -1172,7 +1204,7 @@ const (
 	// WithLimitConcurrentJobs or WithSingletonMode to be skipped
 	// and rescheduled for the next run time rather than being
 	// queued up to wait.
-	LimitModeReschedule = 1
+	LimitModeReschedule LimitMode = iota + 1
 
 	// LimitModeWait causes jobs reaching the limit set in
 	// WithLimitConcurrentJobs or WithSingletonMode to wait
@@ -1198,7 +1230,7 @@ const (
 	//				},
 	//			),
 	//      )
-	LimitModeWait = 2
+	LimitModeWait
 )
 
 // WithLimitConcurrentJobs sets the limit and mode to be used by the

--- a/util.go
+++ b/util.go
@@ -127,6 +127,18 @@ func nextScheduledContains(times []time.Time, t time.Time) bool {
 	return found
 }
 
+// waitGroupWithMutex wraps sync.WaitGroup so that Add() cannot race
+// with Wait(). This addresses the classic "Add called after Wait
+// returned (or with counter == 0)" panic that sync.WaitGroup enforces:
+// gocron dispatches new work concurrently with executor shutdown, and
+// the mutex serializes the two.
+//
+// Invariant the mutex protects: an Add() call is never concurrent with
+// a Wait() call. Done() intentionally does NOT take the mutex, because
+// sync.WaitGroup.Done is already safe to call while Wait is blocked
+// (that's the entire point of Wait). Adding the lock to Done would
+// deadlock any goroutine that Waits on this group from inside
+// wg-tracked work.
 type waitGroupWithMutex struct {
 	wg sync.WaitGroup
 	mu sync.Mutex


### PR DESCRIPTION
Final code-health pass on the v2 line. Cleans up four low-priority review findings that are either strict typing tightening or doc-only, plus a stale pre-commit pin left behind by #934.

## Pre-commit pin bump (calling this out first)

PR #934 added the `modernize` linter to `.golangci.yaml` but did not bump `.pre-commit-config.yaml`'s golangci-lint pin, which was still at `v2.4.0` (modernize wasn't shipped until v2.5+). The hook now fails on **every commit for every contributor** with `unknown linters: modernize`. Bumped pin to `v2.11.4`.

Including it here because without it this PR itself couldn't pass pre-commit. Happy to split into a separate PR if maintainers prefer.

## Changes

- **L3** — `LimitMode` constants are now typed via `iota`:
  ```go
  type LimitMode int
  const (
      LimitModeReschedule LimitMode = iota + 1
      LimitModeWait
  )
  ```
  Previously untyped `= 1`, `= 2`. Users passing raw ints (`WithSingletonMode(3)`) now get a compile-time error at typed call sites. **Non-breaking for standard usage:** untyped-to-typed conversion at the call site means existing `WithLimitConcurrentJobs(N, LimitModeReschedule)` continues to compile identically. Values (1, 2) preserved via `iota + 1`.

- **L5** — Document `defaultCron.IsValid`'s timezone precedence rules (`TZ=`/`CRON_TZ=` prefix wins vs. `location.String()` fallback) and the `Cron.Next()` "strictly after lastRun" contract on the public interface (violating it can spin the scheduler).

- **L7** — Docstrings on `scheduler.go` `select*` handlers and executor's `singletonModeRunner` / `limitModeRunner`. These are the most subtle scheduling / concurrency-model code in the codebase but were almost entirely undocumented. Each new docstring is 2-4 lines, oriented at a new reader trying to trace a channel flow rather than an exhaustive spec.

- **L8** — Document `waitGroupWithMutex`'s invariant: the mutex prevents `Add()` from racing with `Wait()` (fixes `sync.WaitGroup`'s "Add after Wait" panic). `Done()` intentionally does NOT take the lock because `sync.WaitGroup.Done` is already safe to call while `Wait` is blocked; locking `Done` would deadlock any goroutine that `Wait`s on this group from inside wg-tracked work.

## Deferred (explicit non-goals)

- **L4 (receiver-convention consistency)** — Touches every schedule type, setup method, `jobScheduleFromInternal` switch, and `next()` implementation. Big diff, low reader value, real risk of accidentally changing method-set semantics for interface satisfaction. Punt.
- **L6 (banner comment removal)** — 55 five-line banners across `scheduler.go` and `job.go`. Pure whitespace churn; matter of taste. Punt.
- **M7 (WithStartDateTime grace window)** — Still needs a design decision on the tolerance value. Deferred separately.

## Verified

- `go build ./...`: clean
- `golangci-lint run` (with `modernize` + `embeddedstructfieldcheck`): 0 issues
- `go test -race -count=1 ./...`: pass
- `pre-commit run --all-files` (with bumped pin): all hooks pass

## Rollout

Non-breaking. L3's typing tightening is technically observable but only in pathological usages (users constructing values via arithmetic on the untyped constants); standard `WithLimitConcurrentJobs(N, LimitModeReschedule)` usage is unaffected.

After this PR, every finding from the initial code review is either shipped or explicitly deferred with a documented rationale.
