### PR TITLE
ci: gate pre-commit config, add Dependabot pin updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,12 +8,12 @@ Always reference these instructions first and fallback to search or bash command
 - Install dependencies: `go mod tidy`
 - Build the library: `go build -v ./...`
 - Install required tools:
-  - `go install go.uber.org/mock/mockgen@latest` 
+  - `go install go.uber.org/mock/mockgen@latest`
   - `export PATH=$PATH:$(go env GOPATH)/bin` (add to shell profile)
 - Generate mocks: `make mocks`
 - Format code: `make fmt`
 
-### Testing Commands  
+### Testing Commands
 - Run all tests: `make test` -- takes 50 seconds. NEVER CANCEL. Set timeout to 90+ seconds.
 - Run CI tests: `make test_ci` -- takes 50 seconds. NEVER CANCEL. Set timeout to 90+ seconds.
 - Run with coverage: `make test_coverage` -- takes 50 seconds. NEVER CANCEL. Set timeout to 90+ seconds.
@@ -74,7 +74,7 @@ The CI will fail if:
 ```
 .
 ├── README.md              # Main documentation
-├── CONTRIBUTING.md        # Contribution guidelines  
+├── CONTRIBUTING.md        # Contribution guidelines
 ├── SECURITY.md           # Security policy
 ├── Makefile              # Build automation
 ├── go.mod               # Go module definition
@@ -91,7 +91,7 @@ The CI will fail if:
 - `scheduler.go` - Main scheduler implementation
 - `job.go` - Job definitions and scheduling logic
 - `executor.go` - Job execution engine
-- `logger.go` - Logging interfaces and implementations  
+- `logger.go` - Logging interfaces and implementations
 - `distributed.go` - Distributed scheduling support
 - `monitor.go` - Job monitoring interfaces
 - `util.go` - Utility functions
@@ -130,7 +130,7 @@ The CI will fail if:
 
 ### Expected Timings
 - `make test`: ~50 seconds
-- `make test_coverage`: ~50 seconds  
+- `make test_coverage`: ~50 seconds
 - `make test_ci`: ~50 seconds
 - `go build`: ~5 seconds
 - `make mocks`: ~2 seconds

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Maintain pre-commit hook pins (prevents the config/pin drift
+  # that caused #934 to ship a broken .pre-commit-config.yaml).
+  - package-ecosystem: "pre-commit"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - v2
+  pull_request:
+    branches:
+      - v2
+
+name: pre-commit
+jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Run pre-commit
+        uses: pre-commit/[email protected]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 gocron is a job scheduling package which lets you run Go functions at pre-determined intervals.
 
-> Looking for a visual interface?  
+> Looking for a visual interface?
 > Check out [**gocron-ui**](https://github.com/go-co-op/gocron-ui) — a lightweight web dashboard to monitor, trigger, and manage your `gocron` jobs in real time.
 
 If you want to chat, you can find us on Slack at
@@ -63,7 +63,7 @@ func main() {
 
 	// when you're done, shut it down
 	err = s.Shutdown()
-	// or for context-aware teardown: 
+	// or for context-aware teardown:
 	// err = s.ShutdownWithContext(ctx)
 	if err != nil {
 		// handle error
@@ -114,7 +114,7 @@ Jobs can be run at specific time(s) (either once or many times).
 ### Interval Timing
 Jobs can be scheduled with different interval timing modes.
 - [**Interval from scheduled time (default)**](https://pkg.go.dev/github.com/go-co-op/gocron/v2#DurationJob):
-By default, jobs calculate their next run time from when they were scheduled to start, resulting in fixed intervals 
+By default, jobs calculate their next run time from when they were scheduled to start, resulting in fixed intervals
 regardless of execution time. Good for cron-like scheduling at predictable times.
 - [**Interval from completion time**](https://pkg.go.dev/github.com/go-co-op/gocron/v2#WithIntervalFromCompletion):
 Jobs can calculate their next run time from when they complete, ensuring consistent rest periods between executions.
@@ -259,4 +259,3 @@ This project is supported by:
    <img alt="Sentry logo" src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" />
  </picture>
 </a>
-


### PR DESCRIPTION
Adds a CI job that runs `pre-commit run --all-files` on every push and PR to `v2`, plus Dependabot coverage for the pre-commit ecosystem.

## Motivating incident

PR #934 added the `modernize` linter to `.golangci.yaml` but did not bump `.pre-commit-config.yaml`'s golangci-lint pin (still at `v2.4.0` — modernize wasn't shipped until `v2.5+`). Every contributor's pre-commit hook then failed with `unknown linters: modernize` until PR #936 bumped the pin to `v2.11.4`. Nobody noticed for two PRs because contributors either used `--no-verify` locally or had newer local `golangci-lint` binaries that didn't match the pinned version.

The core problem: pre-commit runs its **pinned** golangci-lint, CI runs whatever CI installs, and neither is a `.golangci.yaml`-schema validator. There was no gate that asserted "the config parses under the pinned tool version."

## Changes

**`.github/workflows/pre_commit.yml`** (new) — runs `pre-commit run --all-files` via `pre-commit/[email protected]` on push/PR to `v2`. Matches the style of the existing `go_test.yml` and `file_formatting.yml` workflows (same triggers, same action versions, same runner).

**`.github/dependabot.yml`** — adds the `pre-commit` ecosystem alongside the existing `gomod` and `github-actions` entries. Auto-PRs pin bumps weekly, matching existing cadence.

**`README.md`, `.github/copilot-instructions.md`** — pre-existing trailing-whitespace violations the new gate would fail on merge. Folded in because they are exactly the class of drift this PR is designed to catch. Trivial diffs (deletes 3 trailing spaces across 7 lines).

## Verification

- `go build ./...` — clean
- `golangci-lint run` — 0 issues
- `go test -race -count=1 ./...` — pass (no code touched)
- `pre-commit run --all-files` — pass locally after the whitespace fixes

**Sanity check for the gate itself:** temporarily reverted `.pre-commit-config.yaml`'s pin to `v2.4.0` locally, confirmed `pre-commit run --all-files` fails with `unknown linters: modernize` — the exact failure PR #934 shipped. Restored the pin. This is the failure the CI job will now block on future PRs.

## Non-goals

- Not changing how contributors run pre-commit locally.
- Not adding pre-commit as a required check in branch-protection settings — that's a maintainer/admin decision separate from the workflow existing.
- Not modifying the pinned hook versions (Dependabot will propose those going forward).

## Risk

Very low. The workflow is additive. If it fails, `pre-commit/action` prints the diff of what was changed, so the failure is self-diagnosing.
