### PR TITLE
ci: track Go stable/oldstable instead of pinned versions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,7 +98,7 @@ The CI will fail if:
 - `errors.go` - Error definitions
 
 ### Dependencies and Versions
-- Requires Go 1.23.0+
+- Requires Go 1.23.0+ (CI matrix pins to `stable`/`oldstable` — see `.github/workflows/go_test.yml`)
 - Key dependencies automatically managed via `go mod`:
   - `github.com/google/uuid` - UUID generation
   - `github.com/jonboulle/clockwork` - Time mocking for tests
@@ -117,7 +117,7 @@ The CI will fail if:
 - No application to build - this is a library
 - Version managed via Git tags (v2.x.x)
 - Distribution via Go module system
-- CI tests on Go 1.23 and 1.24
+- CI tests on Go `stable` and `oldstable` (see `.github/workflows/go_test.yml`)
 
 ## Troubleshooting
 

--- a/.github/workflows/go_test.yml
+++ b/.github/workflows/go_test.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.24"
-          - "1.25"
+          - "oldstable"
+          - "stable"
     name: lint and test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "stable"
       - name: Install Python
         uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
Replaces hardcoded Go version pins in the test and pre-commit workflows with `stable` and `oldstable`, which `actions/setup-go` resolves to the two most recent Go releases at run time. As of this PR, that resolves to **Go 1.26 (stable)** and **Go 1.25 (oldstable)**.

## Changes

- **`.github/workflows/go_test.yml`** — matrix now `["oldstable", "stable"]` instead of `["1.24", "1.25"]`.
- **`.github/workflows/pre_commit.yml`** — single-Go job now `stable` instead of `1.25`.
- **`.github/copilot-instructions.md`** — describes the matrix in terms of stable/oldstable so the doc doesn't silently go stale next time Go ships a release.

## Rationale

- New Go releases exercise the library in CI automatically the day they land.
- Old Go versions drop out of the matrix on the same cadence the Go team drops them, keeping CI aligned with the officially-maintained window.
- Removes a class of stale-config drift that had to be manually chased (see PR #934 / #936 / #938 for the analogous pre-commit + golangci-lint pin drift).

## Trade-off

A Go point release that regresses gocron will now break CI without an explicit gocron change. That's the desired signal — we want to know early, not when a user files an issue.

## Non-goals

- Not bumping `go.mod`'s `go 1.22` directive. That is the minimum Go version consumers can compile against, and is independent of the CI matrix ceiling. Bump when there's a concrete reason (a language feature used, a dependency requiring newer Go, etc.).
- Not adding `tip` (bleeding-edge) to the matrix. Would create flakiness without commensurate signal.

## Verification

- Workflow files parse (`pre-commit run --all-files` including `check-yaml` — green).
- No code changes; matrix shape preserved (still 2 versions × 1 platform).
- Once CI runs on this PR, the resolved versions will be visible in the workflow logs.
