### PR TITLE
test(scheduler): regression test for issue #943 OneTimeJob CPU spin

### DIFF
--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3519,11 +3519,11 @@ func TestScheduler_DurationRandomJob_NextRunsIsRaceFree(t *testing.T) {
 	s.Start()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for k := 0; k < 200; k++ {
+			for range 200 {
 				runs, err := j.NextRuns(5)
 				require.NoError(t, err)
 				require.NotNil(t, runs)
@@ -3531,5 +3531,76 @@ func TestScheduler_DurationRandomJob_NextRunsIsRaceFree(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+	require.NoError(t, s.Shutdown())
+}
+
+// TestScheduler_OneTimeJob_PastStartTime_DoesNotSpin is a regression test
+// for issue #943 (100% CPU spin under LimitModeWait + OneTimeJobStartDateTime).
+//
+// The v2.21.2 spin worked as follows: selectStart (and selectNewJob) had
+//
+//	if next.Before(s.now()) {
+//	    for next.Before(s.now()) {
+//	        next = j.next(next)
+//	    }
+//	}
+//
+// For a oneTimeJob whose sortedTimes has been exhausted, next() returns
+// time.Time{} — which is also Before(s.now()). The subsequent call
+// next(time.Time{}) binary-searches to idx=0 and returns sortedTimes[0]
+// (the original past time). The loop oscillates between the past time
+// and the zero time forever, pegging one CPU core inside time.Now().
+// The reporter's pprof profile showed 94% of CPU accounted for by
+// exactly these two lines (see issue #943 attachment).
+//
+// The fix (PR #930) is advancePastNow, which detects both the zero-time
+// return and any non-monotonic step and removes the job cleanly.
+//
+// To force the exhausted-schedule condition deterministically we use a
+// fake clock: register the job with a startAt one minute in the future
+// (so setup validation passes), then advance the clock past startAt
+// before starting the scheduler. selectStart then observes
+// next.Before(s.now()) and would spin on v2.21.2. With the fix, the job
+// is removed and Start() returns promptly.
+func TestScheduler_OneTimeJob_PastStartTime_DoesNotSpin(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	schedulerStart := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+	fakeClock := clockwork.NewFakeClockAt(schedulerStart)
+
+	s := newTestScheduler(t, WithClock(fakeClock))
+
+	// One minute in the future relative to the fake clock — passes
+	// oneTimeJobDefinition.setup's !at.After(now) validation.
+	startAt := schedulerStart.Add(time.Minute)
+	j, err := s.NewJob(
+		OneTimeJob(OneTimeJobStartDateTime(startAt)),
+		NewTask(func() {}),
+	)
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, j.ID())
+
+	// Advance past startAt so selectStart sees a job whose only
+	// schedule time is in the past.
+	fakeClock.Advance(5 * time.Minute)
+
+	// Start() blocks on <-s.startedCh until the scheduler goroutine
+	// signals ready after selectStart completes. If selectStart spins
+	// (v2.21.2 behavior), this signal never arrives and Start() hangs.
+	done := make(chan struct{})
+	go func() {
+		s.Start()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler.Start() did not return within 2s — regression: selectStart is spinning on a past OneTimeJob (issue #943)")
+	}
+
+	// Past OneTimeJob should be silently removed at Start(), not retained
+	// in a poison state.
+	require.Empty(t, s.Jobs(), "exhausted OneTimeJob should be removed by selectStart, not retained")
+
 	require.NoError(t, s.Shutdown())
 }


### PR DESCRIPTION
Adds a regression test locking in the fix for issue #943 — the 100% CPU spin that occurs when a `OneTimeJob` with a `OneTimeJobStartDateTime` is dispatched to `selectStart` (or `selectNewJob`) after its start time has already passed.

## The bug (v2.21.2)

`selectStart` and `selectNewJob` both contained:

```go
if next.Before(s.now()) {
    for next.Before(s.now()) {
        next = j.next(next)
    }
}
```

For a `oneTimeJob` whose sorted schedule list is exhausted, `next()` returns `time.Time{}` — which is also `Before` any wall-clock time. The subsequent call `next(time.Time{})` binary-searches to `idx=0` and returns `sortedTimes[0]` again. The loop oscillates between the past start time and the zero time forever, pegging one CPU core inside `time.Now()`.

The reporter's pprof profile confirms this at line-level: 94% of CPU time attributed to exactly the two lines above, with `time.Now` at 65% and `oneTimeJob.next` (via `slices.BinarySearchFunc`) at 21%.

## The fix (already merged, PR #930 / 593e68b)

`advancePastNow` detects both a zero return and a non-monotonic step from `j.next()` and returns `ok=false`. Callers see `!ok` and remove the job cleanly via `selectRemoveJob`. This PR does not modify that fix — it only adds a regression test.

## Test approach

A fake clock forces the exhausted-schedule condition deterministically:

1. Create the job with `startAt = fakeClock.Now() + 1 minute`. Setup validation passes (`startAt` is in the future).
2. Advance the fake clock by 5 minutes.
3. Call `Start()`. `selectStart` observes `next.Before(s.now())`, enters `advancePastNow`, which returns `(zero, false)` on the first iteration because `oneTimeJob.next(startAt)` returns `time.Time{}`. Job is removed.

Assertions:

- `Start()` returns within 2s. On v2.21.2 this would hang indefinitely because `Scheduler.Start()` blocks on `<-s.startedCh`, which is only signalled after `selectStart`'s job iteration completes.
- `Jobs()` is empty afterward (the exhausted `OneTimeJob` should be silently removed, not retained in a poison state).
- No goroutine leaks (via existing `verifyNoGoroutineLeaks`).

## Negative-control verification

Temporarily reverted `advancePastNow` to the raw spin loop in `selectStart` locally. Test failed at the 2s deadline with exactly:

> `regression: selectStart is spinning on a past OneTimeJob (issue #943)`

Restored the fix; test passes in <1ms. This confirms the test genuinely catches the regression it claims to.

## Verification

- `go test -race -count=1 -timeout 120s ./...` — pass (~60s)
- `golangci-lint run ./...` — 0 issues
- Negative control (above)

## Non-goals

- Does not modify any production code — pure test addition.
- Does not cover the `selectNewJob` variant of the spin (post-`Start()` `NewJob` with a past `startAt`). That path also uses `advancePastNow` and shares the same fix, but reliably triggering it requires racing the fake clock against channel dispatch, which is fragile. The `selectStart` path exercises the same primitive.

## Refs

- Bug report: #943
- Fix: #930 (already merged, unreleased)
- Related unreleased fixes for the same issue class: #931, #932, #933, #935, #936, #937, #938, #942
