### PR TITLE
feat(scheduler): WithStartAtGrace opt-in tolerance for late first-run dispatch

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -58,6 +58,7 @@ var (
 	ErrWithNameEmpty                 = errors.New("gocron: WithName: name must not be empty")
 	ErrWithStartDateTimePast         = errors.New("gocron: WithStartDateTime: start must not be in the past")
 	ErrWithStartDateTimePastZero     = errors.New("gocron: WithStartDateTime: start must not be zero")
+	ErrWithStartAtGraceNegative      = errors.New("gocron: WithStartAtGrace: grace must not be negative")
 	ErrWithStopDateTimePast          = errors.New("gocron: WithStopDateTime: end must not be in the past")
 	ErrStartTimeLaterThanEndTime     = errors.New("gocron: WithStartDateTime: start must not be later than end")
 	ErrStopTimeEarlierThanStartTime  = errors.New("gocron: WithStopDateTime: end must not be earlier than start")

--- a/job.go
+++ b/job.go
@@ -62,17 +62,24 @@ type internalJob struct {
 	// nextScheduled times.
 	nextScheduled []time.Time
 
-	lastRun                time.Time
-	lastRunStartedAt       time.Time
-	lastRunCompletedAt     time.Time
-	function               any
-	parameters             []any
-	timer                  clockwork.Timer
-	singletonMode          bool
-	singletonLimitMode     LimitMode
-	limitRunsTo            *limitRunsTo
-	startTime              time.Time
-	startImmediately       bool
+	lastRun            time.Time
+	lastRunStartedAt   time.Time
+	lastRunCompletedAt time.Time
+	function           any
+	parameters         []any
+	timer              clockwork.Timer
+	singletonMode      bool
+	singletonLimitMode LimitMode
+	limitRunsTo        *limitRunsTo
+	startTime          time.Time
+	startImmediately   bool
+	// startAtGrace is the maximum tolerated lateness for the first
+	// scheduled run. If the scheduler dispatches a job and finds that
+	// the computed first-run time has already passed, the run fires
+	// immediately at the current time when now-firstRun <= startAtGrace,
+	// and is otherwise treated as exhausted (strict behavior, preserved
+	// as the default when startAtGrace is 0). See WithStartAtGrace.
+	startAtGrace           time.Duration
 	stopTime               time.Time
 	intervalFromCompletion bool
 	// event listeners
@@ -652,6 +659,16 @@ func (o oneTimeJobDefinition) setup(j *internalJob, _ *time.Location, now time.T
 	if !j.startImmediately && len(sortedTimes) == 0 {
 		return ErrOneTimeJobStartDateTimePast
 	}
+	if len(sortedTimes) > 0 {
+		// Record the earliest scheduled run so downstream scheduling logic
+		// (selectStart / selectNewJob / firstRunOrGrace) has a concrete
+		// reference point rather than relying on oneTimeJob.next(now) to
+		// re-derive it. This matters for WithStartAtGrace, where the fake
+		// or wall clock may advance past sortedTimes[0] between setup and
+		// dispatch: without this, oneTimeJob.next(now) returns zero (all
+		// entries already elapsed) and grace has no drift to measure.
+		j.startTime = sortedTimes[0]
+	}
 	j.jobSchedule = oneTimeJob{sortedTimes: sortedTimes}
 	return nil
 }
@@ -853,6 +870,53 @@ func WithIntervalFromCompletion() JobOption {
 func WithStartAt(option StartAtOption) JobOption {
 	return func(j *internalJob, now time.Time) error {
 		return option(j, now)
+	}
+}
+
+// WithStartAtGrace configures the maximum tolerated lateness for the
+// job's first scheduled run. It is a robustness knob for jobs whose
+// scheduled first-run time may already have passed by the time the
+// scheduler dispatches them.
+//
+// NewJob validates and enqueues a job synchronously, but the scheduler
+// dispatch loop processes new jobs asynchronously. Under load
+// (heavy LimitModeWait queues, GC pauses, event storms) or with race-y
+// scheduling patterns such as
+//
+//	OneTimeJob(OneTimeJobStartDateTime(time.Now().Add(randomDelay)))
+//
+// dispatch can lag past the intended start time. Without a grace
+// setting the scheduler treats the missed first run as exhausted and
+// silently removes the job (see issue #943 for the workload that
+// motivated this option).
+//
+// Semantics:
+//   - Applies to the FIRST scheduled run only. Subsequent runs of
+//     recurring schedules follow the schedule's normal next()
+//     progression.
+//   - When dispatch observes firstRun.Before(now):
+//   - if now.Sub(firstRun) <= grace, the job fires immediately at
+//     the current time (the original firstRun is preserved on the
+//     job for observability via Job.NextRun / event listeners);
+//   - otherwise the job is treated as exhausted (existing behavior).
+//   - A grace-triggered fire still respects stopTime: if stopTime has
+//     already passed, the job is removed rather than fired.
+//   - A grace-triggered fire still respects LimitMode: the run enters
+//     the executor queue like any other dispatch.
+//   - No catch-up is performed for recurring schedules. If the
+//     scheduler was down long enough to miss multiple cron ticks, at
+//     most one grace-triggered fire happens on startup, and the
+//     schedule resumes from schedule.Next(now).
+//
+// Default: 0 (strict — any past first-run time at dispatch is treated
+// as exhausted). A negative value returns ErrWithStartAtGraceNegative.
+func WithStartAtGrace(grace time.Duration) JobOption {
+	return func(j *internalJob, _ time.Time) error {
+		if grace < 0 {
+			return ErrWithStartAtGraceNegative
+		}
+		j.startAtGrace = grace
+		return nil
 	}
 }
 
@@ -1718,7 +1782,7 @@ func (j job) NextRuns(count int) ([]time.Time, error) {
 	}
 
 	out := make([]time.Time, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		if i < lengthNextScheduled {
 			out[i] = ij.nextScheduled[i]
 			continue

--- a/scheduler.go
+++ b/scheduler.go
@@ -418,6 +418,50 @@ func (s *scheduler) advancePastNow(j internalJob, next time.Time) (time.Time, bo
 	return next, true
 }
 
+// firstRunAction communicates how the scheduler should handle a
+// newly-dispatched job's first scheduled run after firstRunOrGrace has
+// resolved any past-time drift.
+type firstRunAction uint8
+
+const (
+	// firstRunSchedule means the caller should schedule a timer for the
+	// returned time as normal.
+	firstRunSchedule firstRunAction = iota
+	// firstRunFireNow means the returned time is the current wall time
+	// (grace-triggered) and the caller should dispatch on jobsIn
+	// immediately rather than arming a zero-duration timer. This
+	// matches the semantics of startImmediately.
+	firstRunFireNow
+	// firstRunDrop means the schedule is exhausted (or past its stop
+	// time) and the caller should remove the job.
+	firstRunDrop
+)
+
+// firstRunOrGrace resolves the first-run time for a newly-dispatched
+// job. Behavior:
+//
+//   - If next is not before now, it is returned with firstRunSchedule.
+//   - If next is before now and the job's startAtGrace tolerates the
+//     drift (now.Sub(next) <= j.startAtGrace), now is returned with
+//     firstRunFireNow so the caller can dispatch immediately.
+//   - Otherwise advancePastNow is consulted; if it too fails to find a
+//     future run the schedule is exhausted and firstRunDrop is returned.
+//
+// See WithStartAtGrace.
+func (s *scheduler) firstRunOrGrace(j internalJob, next time.Time) (time.Time, firstRunAction) {
+	now := s.now()
+	if !next.Before(now) {
+		return next, firstRunSchedule
+	}
+	if j.startAtGrace > 0 && now.Sub(next) <= j.startAtGrace {
+		return now, firstRunFireNow
+	}
+	if advanced, ok := s.advancePastNow(j, next); ok {
+		return advanced, firstRunSchedule
+	}
+	return time.Time{}, firstRunDrop
+}
+
 // selectExecJobsOutForRescheduling handles the executor's post-run
 // notification for a job that just started. Advances j.nextRun past
 // now, updates the timer, and appends to nextScheduled. No-op if the
@@ -647,12 +691,32 @@ func (s *scheduler) selectNewJob(in newJobIn) {
 			}
 
 			if next.Before(s.now()) {
-				var ok bool
-				next, ok = s.advancePastNow(j, next)
-				if !ok {
+				var action firstRunAction
+				next, action = s.firstRunOrGrace(j, next)
+				switch action {
+				case firstRunDrop:
 					s.jobs[j.id] = j
 					in.cancel()
 					s.selectRemoveJob(j.id)
+					return
+				case firstRunFireNow:
+					if !j.stopTime.IsZero() && !next.Before(j.stopTime) {
+						s.jobs[j.id] = j
+						in.cancel()
+						s.selectRemoveJob(j.id)
+						return
+					}
+					select {
+					case <-s.shutdownCtx.Done():
+					case s.exec.jobsIn <- jobIn{
+						id:            j.id,
+						shouldSendOut: true,
+					}:
+					}
+					j.startTime = next
+					j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
+					s.jobs[j.id] = j
+					in.cancel()
 					return
 				}
 			}
@@ -722,10 +786,27 @@ func (s *scheduler) selectStart() {
 				next = j.next(s.now())
 			}
 			if next.Before(s.now()) {
-				var ok bool
-				next, ok = s.advancePastNow(j, next)
-				if !ok {
+				var action firstRunAction
+				next, action = s.firstRunOrGrace(j, next)
+				switch action {
+				case firstRunDrop:
 					s.selectRemoveJob(id)
+					continue
+				case firstRunFireNow:
+					if !j.stopTime.IsZero() && !next.Before(j.stopTime) {
+						s.selectRemoveJob(id)
+						continue
+					}
+					select {
+					case <-s.shutdownCtx.Done():
+					case s.exec.jobsIn <- jobIn{
+						id:            id,
+						shouldSendOut: true,
+					}:
+					}
+					j.startTime = next
+					j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
+					s.jobs[id] = j
 					continue
 				}
 			}
@@ -877,7 +958,7 @@ func (s *scheduler) verifyVariadic(taskFunc reflect.Value, tsk task, variadicSta
 }
 
 func (s *scheduler) verifyNonVariadic(taskFunc reflect.Value, tsk task, length int) error {
-	for i := 0; i < length; i++ {
+	for i := range length {
 		argumentType := reflect.TypeOf(tsk.parameters[i])
 		t1 := argumentType.Kind()
 		if t1 == reflect.Interface || t1 == reflect.Pointer {
@@ -909,7 +990,7 @@ func (s *scheduler) verifyParameterType(taskFunc reflect.Value, tsk task) error 
 	return s.verifyNonVariadic(taskFunc, tsk, expectedParameterLength)
 }
 
-var contextType = reflect.TypeOf((*context.Context)(nil)).Elem()
+var contextType = reflect.TypeFor[context.Context]()
 
 func (s *scheduler) addOrUpdateJob(id uuid.UUID, definition JobDefinition, taskWrapper Task, options []JobOption) (Job, error) {
 	j := internalJob{}

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3604,3 +3604,225 @@ func TestScheduler_OneTimeJob_PastStartTime_DoesNotSpin(t *testing.T) {
 
 	require.NoError(t, s.Shutdown())
 }
+
+// TestScheduler_WithStartAtGrace covers the WithStartAtGrace JobOption,
+// which lets callers opt into a bounded tolerance for late first-run
+// dispatch. Without grace, a job whose scheduled start time has already
+// elapsed by dispatch is silently removed (strict semantics, preserved
+// as the default). With grace, if the elapsed drift is within the
+// configured window the run fires immediately; if it exceeds the window
+// the strict behavior kicks in.
+//
+// See WithStartAtGrace docstring and issue #943 for the workload that
+// motivated this option.
+func TestScheduler_WithStartAtGrace(t *testing.T) {
+	t.Run("within grace fires the missed one-time run", func(t *testing.T) {
+		defer verifyNoGoroutineLeaks(t)
+
+		schedulerStart := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+		fakeClock := clockwork.NewFakeClockAt(schedulerStart)
+
+		s := newTestScheduler(t, WithClock(fakeClock))
+
+		var runs atomic.Uint32
+		done := make(chan struct{}, 1)
+		startAt := schedulerStart.Add(time.Minute)
+		_, err := s.NewJob(
+			OneTimeJob(OneTimeJobStartDateTime(startAt)),
+			NewTask(func() {
+				runs.Add(1)
+				select {
+				case done <- struct{}{}:
+				default:
+				}
+			}),
+			WithStartAtGrace(10*time.Minute),
+		)
+		require.NoError(t, err)
+
+		// Advance past startAt but still within the 10-minute grace window.
+		fakeClock.Advance(5 * time.Minute)
+		s.Start()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected grace-triggered fire within 2s")
+		}
+		require.Equal(t, uint32(1), runs.Load())
+
+		require.NoError(t, s.Shutdown())
+	})
+
+	t.Run("outside grace drops the job", func(t *testing.T) {
+		defer verifyNoGoroutineLeaks(t)
+
+		schedulerStart := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+		fakeClock := clockwork.NewFakeClockAt(schedulerStart)
+
+		s := newTestScheduler(t, WithClock(fakeClock))
+
+		var runs atomic.Uint32
+		startAt := schedulerStart.Add(time.Minute)
+		_, err := s.NewJob(
+			OneTimeJob(OneTimeJobStartDateTime(startAt)),
+			NewTask(func() { runs.Add(1) }),
+			WithStartAtGrace(2*time.Minute),
+		)
+		require.NoError(t, err)
+
+		// Advance past startAt by more than the grace window (10m > 2m).
+		fakeClock.Advance(10 * time.Minute)
+		s.Start()
+
+		// Give the scheduler time to process the queue and remove the job.
+		time.Sleep(100 * time.Millisecond)
+		require.Empty(t, s.Jobs(), "job past its grace window should be removed")
+		require.Equal(t, uint32(0), runs.Load(), "no run should happen for a dropped job")
+
+		require.NoError(t, s.Shutdown())
+	})
+
+	t.Run("default (no option) preserves strict drop behavior", func(t *testing.T) {
+		defer verifyNoGoroutineLeaks(t)
+
+		schedulerStart := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+		fakeClock := clockwork.NewFakeClockAt(schedulerStart)
+
+		s := newTestScheduler(t, WithClock(fakeClock))
+
+		var runs atomic.Uint32
+		startAt := schedulerStart.Add(time.Minute)
+		_, err := s.NewJob(
+			OneTimeJob(OneTimeJobStartDateTime(startAt)),
+			NewTask(func() { runs.Add(1) }),
+			// No WithStartAtGrace — must behave identically to pre-feature.
+		)
+		require.NoError(t, err)
+
+		fakeClock.Advance(5 * time.Minute)
+		s.Start()
+
+		time.Sleep(100 * time.Millisecond)
+		require.Empty(t, s.Jobs(), "default (grace=0) must drop past OneTimeJob")
+		require.Equal(t, uint32(0), runs.Load())
+
+		require.NoError(t, s.Shutdown())
+	})
+
+	t.Run("grace of zero is equivalent to no option", func(t *testing.T) {
+		defer verifyNoGoroutineLeaks(t)
+
+		schedulerStart := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+		fakeClock := clockwork.NewFakeClockAt(schedulerStart)
+
+		s := newTestScheduler(t, WithClock(fakeClock))
+
+		var runs atomic.Uint32
+		startAt := schedulerStart.Add(time.Minute)
+		_, err := s.NewJob(
+			OneTimeJob(OneTimeJobStartDateTime(startAt)),
+			NewTask(func() { runs.Add(1) }),
+			WithStartAtGrace(0),
+		)
+		require.NoError(t, err)
+
+		fakeClock.Advance(5 * time.Minute)
+		s.Start()
+
+		time.Sleep(100 * time.Millisecond)
+		require.Empty(t, s.Jobs())
+		require.Equal(t, uint32(0), runs.Load())
+
+		require.NoError(t, s.Shutdown())
+	})
+
+	t.Run("negative grace returns an error at NewJob", func(t *testing.T) {
+		defer verifyNoGoroutineLeaks(t)
+
+		s := newTestScheduler(t)
+		_, err := s.NewJob(
+			OneTimeJob(OneTimeJobStartImmediately()),
+			NewTask(func() {}),
+			WithStartAtGrace(-1*time.Second),
+		)
+		require.ErrorIs(t, err, ErrWithStartAtGraceNegative)
+
+		require.NoError(t, s.Shutdown())
+	})
+
+	t.Run("grace-triggered fire respects stopTime", func(t *testing.T) {
+		defer verifyNoGoroutineLeaks(t)
+
+		schedulerStart := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+		fakeClock := clockwork.NewFakeClockAt(schedulerStart)
+
+		s := newTestScheduler(t, WithClock(fakeClock))
+
+		var runs atomic.Uint32
+		startAt := schedulerStart.Add(time.Minute)
+		stopAt := schedulerStart.Add(2 * time.Minute)
+		_, err := s.NewJob(
+			OneTimeJob(OneTimeJobStartDateTime(startAt)),
+			NewTask(func() { runs.Add(1) }),
+			WithStartAtGrace(1*time.Hour),
+			WithStopAt(WithStopDateTime(stopAt)),
+		)
+		require.NoError(t, err)
+
+		// Advance past BOTH startAt and stopAt — within grace but past stop.
+		fakeClock.Advance(10 * time.Minute)
+		s.Start()
+
+		time.Sleep(100 * time.Millisecond)
+		require.Empty(t, s.Jobs(), "grace must not fire a job past its stopTime")
+		require.Equal(t, uint32(0), runs.Load())
+
+		require.NoError(t, s.Shutdown())
+	})
+
+	t.Run("applies to first run of recurring schedules and does not catch up", func(t *testing.T) {
+		defer verifyNoGoroutineLeaks(t)
+
+		schedulerStart := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+		fakeClock := clockwork.NewFakeClockAt(schedulerStart)
+
+		s := newTestScheduler(t, WithClock(fakeClock))
+
+		var runs atomic.Uint32
+		firstFired := make(chan struct{}, 1)
+		startAt := schedulerStart.Add(time.Minute)
+		_, err := s.NewJob(
+			DurationJob(30*time.Second),
+			NewTask(func() {
+				runs.Add(1)
+				select {
+				case firstFired <- struct{}{}:
+				default:
+				}
+			}),
+			WithStartAt(WithStartDateTime(startAt)),
+			WithStartAtGrace(30*time.Minute),
+		)
+		require.NoError(t, err)
+
+		// Advance five minutes past startAt — well within grace, well past
+		// several 30-second intervals. We expect exactly ONE grace-triggered
+		// fire on Start(), NOT catch-up fires for every missed 30s tick.
+		fakeClock.Advance(5 * time.Minute)
+		s.Start()
+
+		select {
+		case <-firstFired:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected first grace-triggered fire within 2s")
+		}
+
+		// Give the scheduler a moment to (incorrectly) queue catch-ups if
+		// it were going to. It shouldn't.
+		time.Sleep(100 * time.Millisecond)
+		require.Equal(t, uint32(1), runs.Load(), "exactly one grace-triggered fire, no catch-up")
+
+		require.NoError(t, s.Shutdown())
+	})
+}


### PR DESCRIPTION
Adds `WithStartAtGrace(d time.Duration) JobOption` — an opt-in tolerance for late first-run dispatch. Default `0` preserves current strict behavior; positive values opt into a bounded catch-up window.

## Motivation

Discussed in the follow-up conversation on #943. `NewJob` validates and enqueues synchronously, but the scheduler dispatch loop processes new jobs asynchronously. Under load (heavy `LimitModeWait` queues, GC pauses) or with race-y scheduling patterns like

```go
OneTimeJob(OneTimeJobStartDateTime(time.Now().Add(randomDelay)))
```

dispatch can lag past the intended start time. Without grace, the scheduler treats the missed first run as exhausted and silently removes the job. Previously this manifested as a 100% CPU spin (fixed in #930); now it's a clean silent drop. Neither is what the reporter's workload wants: *"random-delay-then-upload really means upload roughly then, don't drop it if my scheduler is a millisecond late."*

## API

```go
_, err := s.NewJob(
    OneTimeJob(OneTimeJobStartDateTime(startAt)),
    NewTask(uploadFn),
    WithStartAtGrace(30 * time.Second),
)
```

## Semantics

| Situation | Behavior |
|-----------|----------|
| `firstRun` not in the past | Schedule as normal (unchanged). |
| `firstRun` in the past, `now - firstRun <= grace` | Fire immediately at `now`. |
| `firstRun` in the past, `now - firstRun > grace` | Drop the job (existing strict behavior). |
| `firstRun` in the past, grace covers drift, but `stopTime <= now` | Drop (stopTime wins). |
| `WithStartAtGrace(0)` | Identical to omitting the option. |
| `WithStartAtGrace(-1s)` | `NewJob` returns `ErrWithStartAtGraceNegative`. |
| Recurring schedules (DurationJob, CronJob, etc.) | Applies to the **first fire only**. No catch-up for missed intervals. |

Explicit non-goals (deliberately deferred, matching the design discussion):

- No catch-up for multiple missed cron ticks. That path leads to `concurrencyPolicy`-style complexity (see K8s CronJob) — worth revisiting when there's demand.
- No visibility hooks for silent drops. The existing `Monitor` interface can be extended incrementally if users ask.

## Implementation notes

- New field `internalJob.startAtGrace time.Duration`.
- New `firstRunAction` enum ({`schedule`, `fireNow`, `drop`}) returned by `firstRunOrGrace`, replacing the previous `(time, bool)` return. Callers in `selectStart` and `selectNewJob` switch on the action.
- Grace-triggered fires dispatch directly on `jobsIn` (like `startImmediately`), **not** through a zero-duration `AfterFunc`. A `FakeClock.AfterFunc(0, f)` doesn't fire without an explicit `Advance`, which would break test determinism and — more importantly — real-world grace fires under a real clock could be arbitrarily delayed by scheduler overhead.
- `oneTimeJobDefinition.setup` now records `j.startTime = sortedTimes[0]`. Previously this field was left zero for OneTimeJob, forcing `selectStart` to derive first-run from `j.next(now)`. For a OneTimeJob whose sortedTimes has already elapsed by dispatch, that derivation returns `time.Time{}` — grace then has no reference point to measure drift from. Recording `sortedTimes[0]` upfront makes `firstRunOrGrace` see the true drift.

## Tests

Seven subtests in `TestScheduler_WithStartAtGrace`:

1. **within grace fires the missed one-time run** — 5m drift, 10m grace → job runs.
2. **outside grace drops the job** — 10m drift, 2m grace → job dropped, no run.
3. **default (no option) preserves strict drop behavior** — no `WithStartAtGrace` → identical to pre-feature.
4. **grace of zero is equivalent to no option** — explicit `WithStartAtGrace(0)` behaves the same as omission.
5. **negative grace returns an error at NewJob** — `ErrWithStartAtGraceNegative`.
6. **grace-triggered fire respects stopTime** — 10m drift, 1h grace, 2m stopTime → dropped.
7. **applies to first run of recurring schedules and does not catch up** — `DurationJob(30s)` + `WithStartAt(...)` + `WithStartAtGrace(30m)`, advance 5m past start → asserts **exactly one** fire, not ten catch-up fires.

## Negative-control verification

Two guarded code paths, each disabled in turn to confirm the tests catch regressions:

1. Removed the `if j.startAtGrace > 0 && now.Sub(next) <= j.startAtGrace` branch in `firstRunOrGrace` → subtests 1, 6, 7 fail with meaningful messages ("expected grace-triggered fire within 2s").
2. Removed the `j.startTime = sortedTimes[0]` line in `oneTimeJobDefinition.setup` → subtest 1 fails (OneTimeJob-specific), while the DurationJob subtest still passes (it uses `WithStartAt` which sets `startTime` on its own). This confirms the anchor change is scoped correctly.

Both guards restored; full suite green.

## Compatibility

- No API breakage — `WithStartAtGrace` is a new additive option.
- Default behavior unchanged: `WithStartAtGrace(0)` and "no option" both preserve the strict semantics that shipped in #930.
- #943 regression test (`TestScheduler_OneTimeJob_PastStartTime_DoesNotSpin`) still passes — it doesn't set grace, so strict drop still applies.

## Verified

- `go test -race -count=1 -timeout 300s ./...` — pass (~61s)
- `golangci-lint run ./...` — 0 issues
- Negative-control on both guarded paths (above)

## Refs

- Motivating issue: #943
- Spin fix that this feature complements: #930
- Regression test for the spin fix: #944
