### PR TITLE
fix(executor,scheduler): use injected clock for job timing and guard reschedule loop

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -476,7 +476,7 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	_ = callJobFuncWithParams(j.beforeJobRuns, j.id, j.name)
 
 	//  Notify job started
-	actualStartTime := time.Now()
+	actualStartTime := e.clock.Now()
 	if e.scheduler != nil && e.scheduler.schedulerMonitor != nil {
 		jobObj := e.scheduler.jobFromInternalJob(j)
 		e.scheduler.notifyJobStarted(jobObj)
@@ -515,7 +515,7 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 		}
 	}
 
-	startTime := time.Now()
+	startTime := e.clock.Now()
 	select {
 	case e.jobTimingUpdateCh <- jobTimingUpdate{id: j.id, startedAt: startTime}:
 	case <-e.ctx.Done():
@@ -525,11 +525,11 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	} else {
 		err = callJobFuncWithParams(j.function, j.parameters...)
 	}
-	e.recordJobTiming(startTime, time.Now(), j)
+	e.recordJobTiming(startTime, e.clock.Now(), j)
 	if err != nil {
 		_ = callJobFuncWithParams(j.afterJobRunsWithError, j.id, j.name, err)
 		e.incrementJobCounter(j, Fail)
-		endTime := time.Now()
+		endTime := e.clock.Now()
 		e.recordJobTimingWithStatus(startTime, endTime, j, Fail, err)
 		select {
 		case e.jobTimingUpdateCh <- jobTimingUpdate{id: j.id, completedAt: endTime}:
@@ -544,7 +544,7 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 	} else {
 		_ = callJobFuncWithParams(j.afterJobRuns, j.id, j.name)
 		e.incrementJobCounter(j, Success)
-		endTime := time.Now()
+		endTime := e.clock.Now()
 		e.recordJobTimingWithStatus(startTime, endTime, j, Success, nil)
 		select {
 		case e.jobTimingUpdateCh <- jobTimingUpdate{id: j.id, completedAt: endTime}:

--- a/scheduler.go
+++ b/scheduler.go
@@ -304,11 +304,14 @@ func (s *scheduler) stopScheduler() {
 	}
 	var err error
 	if s.started.Load() {
-		t := time.NewTimer(s.exec.stopTimeout + 1*time.Second)
+		// Use the executor's clock so fake clocks in tests behave
+		// consistently with the rest of the shutdown path (executor.stop
+		// already times out on e.clock).
+		t := s.exec.clock.NewTimer(s.exec.stopTimeout + 1*time.Second)
 		select {
 		case err = <-s.exec.done:
 			t.Stop()
-		case <-t.C:
+		case <-t.Chan():
 			err = ErrStopExecutorTimedOut
 		}
 	}
@@ -409,6 +412,25 @@ func (s *scheduler) selectRemoveJob(id uuid.UUID) {
 // they treat an exhausted schedule and remove the job.
 func (s *scheduler) advancePastNow(j internalJob, next time.Time) (time.Time, bool) {
 	for next.Before(s.now()) {
+		n := j.next(next)
+		if n.IsZero() || !n.After(next) {
+			return time.Time{}, false
+		}
+		next = n
+	}
+	return next, true
+}
+
+// advanceNextPastDuplicates advances next past any values already present in
+// j.nextScheduled (e.g. when a job is being rescheduled off the same next-run
+// value as before). It returns ok=false if j.next ever produces the zero time
+// or fails to make forward progress, which would otherwise either loop forever
+// or fall through with a zero next that arms AfterFunc with a large negative
+// duration and busy-loops the scheduler goroutine. This mirrors the guard in
+// advancePastNow; callers should treat ok=false as an exhausted schedule and
+// remove the job. See issue #943 for the failure class.
+func (s *scheduler) advanceNextPastDuplicates(j internalJob, next time.Time) (time.Time, bool) {
+	for nextScheduledContains(j.nextScheduled, next) {
 		n := j.next(next)
 		if n.IsZero() || !n.After(next) {
 			return time.Time{}, false
@@ -538,8 +560,11 @@ func (s *scheduler) selectExecJobsOutForRescheduling(id uuid.UUID) {
 		// if the next value is a duplicate of what's already in the nextScheduled slice, for example:
 		// - the job is being rescheduled off the same next run value as before
 		// increment to the next, next value
-		for nextScheduledContains(j.nextScheduled, next) {
-			next = j.next(next)
+		var ok bool
+		next, ok = s.advanceNextPastDuplicates(j, next)
+		if !ok {
+			s.selectRemoveJob(id)
+			return
 		}
 	}
 

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -3826,3 +3826,165 @@ func TestScheduler_WithStartAtGrace(t *testing.T) {
 		require.NoError(t, s.Shutdown())
 	})
 }
+
+// stubSchedule is a test jobSchedule whose next() behavior is fully
+// controlled by nextFunc, letting tests simulate exhausted or
+// misbehaving schedules (zero / non-advancing next values).
+type stubSchedule struct {
+	nextFunc func(lastRun time.Time) time.Time
+}
+
+func (s stubSchedule) next(lastRun time.Time) time.Time {
+	return s.nextFunc(lastRun)
+}
+
+// TestScheduler_advanceNextPastDuplicates covers the guard that prevents
+// selectExecJobsOutForRescheduling from looping forever (or arming a
+// zero-time timer that busy-loops) when a schedule's next() returns the
+// zero time or fails to advance while skipping duplicate nextScheduled
+// entries. See issue #943 for the failure class.
+func TestScheduler_advanceNextPastDuplicates(t *testing.T) {
+	base := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+	s := &scheduler{location: time.UTC}
+
+	t.Run("no duplicate returns next unchanged", func(t *testing.T) {
+		j := internalJob{
+			jobSchedule:   stubSchedule{nextFunc: func(_ time.Time) time.Time { t.Fatal("next must not be called"); return time.Time{} }},
+			nextScheduled: []time.Time{base.Add(time.Hour)},
+		}
+		got, ok := s.advanceNextPastDuplicates(j, base)
+		require.True(t, ok)
+		require.Equal(t, base, got)
+	})
+
+	t.Run("advances past duplicate to a future non-duplicate", func(t *testing.T) {
+		dup := base.Add(time.Minute)
+		want := base.Add(2 * time.Minute)
+		j := internalJob{
+			jobSchedule:   stubSchedule{nextFunc: func(_ time.Time) time.Time { return want }},
+			nextScheduled: []time.Time{dup},
+		}
+		got, ok := s.advanceNextPastDuplicates(j, dup)
+		require.True(t, ok)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("non-advancing next returns ok=false instead of spinning", func(t *testing.T) {
+		dup := base.Add(time.Minute)
+		j := internalJob{
+			// next() keeps returning the same duplicate value -> no forward progress.
+			jobSchedule:   stubSchedule{nextFunc: func(_ time.Time) time.Time { return dup }},
+			nextScheduled: []time.Time{dup},
+		}
+		done := make(chan struct{})
+		var ok bool
+		go func() {
+			_, ok = s.advanceNextPastDuplicates(j, dup)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("advanceNextPastDuplicates spun on a non-advancing next() (regression)")
+		}
+		require.False(t, ok, "non-advancing schedule must be reported as exhausted")
+	})
+
+	t.Run("zero next returns ok=false", func(t *testing.T) {
+		dup := base.Add(time.Minute)
+		j := internalJob{
+			jobSchedule:   stubSchedule{nextFunc: func(_ time.Time) time.Time { return time.Time{} }},
+			nextScheduled: []time.Time{dup},
+		}
+		_, ok := s.advanceNextPastDuplicates(j, dup)
+		require.False(t, ok, "zero next must be reported as exhausted")
+	})
+}
+
+// TestScheduler_advancePastNow exercises the past-time guard directly,
+// complementing the integration-level regression test
+// TestScheduler_OneTimeJob_PastStartTime_DoesNotSpin.
+func TestScheduler_advancePastNow(t *testing.T) {
+	now := time.Date(2026, time.July, 9, 12, 0, 0, 0, time.UTC)
+	s := &scheduler{location: time.UTC}
+	s.exec.clock = clockwork.NewFakeClockAt(now)
+
+	t.Run("already-future next returned unchanged", func(t *testing.T) {
+		future := now.Add(time.Hour)
+		j := internalJob{jobSchedule: stubSchedule{nextFunc: func(_ time.Time) time.Time { t.Fatal("next must not be called"); return time.Time{} }}}
+		got, ok := s.advancePastNow(j, future)
+		require.True(t, ok)
+		require.Equal(t, future, got)
+	})
+
+	t.Run("non-advancing next returns ok=false instead of spinning", func(t *testing.T) {
+		past := now.Add(-time.Hour)
+		j := internalJob{jobSchedule: stubSchedule{nextFunc: func(lastRun time.Time) time.Time { return lastRun }}}
+		done := make(chan struct{})
+		var ok bool
+		go func() {
+			_, ok = s.advancePastNow(j, past)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("advancePastNow spun on a non-advancing next() (regression)")
+		}
+		require.False(t, ok)
+	})
+}
+
+// TestScheduler_ExecutionTimeUsesInjectedClock verifies that job timing
+// metrics are measured with the scheduler's injected clock rather than the
+// wall clock. With a fake clock, a job that advances the clock by a known
+// duration during execution must report that same duration as its execution
+// time. Prior to the fix, runJob captured start/end via time.Now(), so the
+// reported duration reflected wall time (~0) instead of the injected clock.
+func TestScheduler_ExecutionTimeUsesInjectedClock(t *testing.T) {
+	defer verifyNoGoroutineLeaks(t)
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2050, time.January, 1, 0, 0, 0, 0, time.UTC))
+	monitor := newTestSchedulerMonitor()
+
+	s := newTestScheduler(t,
+		WithClock(fakeClock),
+		WithSchedulerMonitor(monitor),
+	)
+
+	const jobDuration = 5 * time.Second
+	ran := make(chan struct{}, 1)
+	_, err := s.NewJob(
+		DurationJob(time.Hour),
+		NewTask(func() {
+			// Simulate work that takes jobDuration on the injected clock.
+			fakeClock.Advance(jobDuration)
+			select {
+			case ran <- struct{}{}:
+			default:
+			}
+		}),
+		WithStartAt(WithStartImmediately()),
+	)
+	require.NoError(t, err)
+
+	s.Start()
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not run within 2s")
+	}
+
+	require.NoError(t, s.Shutdown())
+
+	monitor.mu.RLock()
+	execTimes := append([]time.Duration(nil), monitor.jobExecutionTimes...)
+	monitor.mu.RUnlock()
+
+	require.NotEmpty(t, execTimes, "expected at least one JobExecutionTime notification")
+	// With the injected clock, execution time equals the advanced duration.
+	// With the wall-clock bug it would be sub-millisecond.
+	require.GreaterOrEqual(t, execTimes[0], jobDuration,
+		"execution time must be measured on the injected clock (got %s, want >= %s)", execTimes[0], jobDuration)
+}


### PR DESCRIPTION
## Summary

Two correctness fixes surfaced by a fresh Principal-Engineer review of `v2` HEAD, plus a small consistency fix. Both are latent under the default real clock but bite users of `WithClock` (deterministic tests, simulation) and misbehaving/exhausted schedules.

### 1. `runJob` mixed wall clock and injected clock (High)

`executor.runJob` evaluated `stopTimeReached` against the injected clock (`e.clock.Now()`) but measured all timing — `actualStartTime`, `startTime`, `endTime` — with `time.Now()`. Because every scheduled time flows through the injected clock, under `WithClock`:

- `JobSchedulingDelay(scheduledTime, actualStartTime)` compared a **fake-clock** scheduled time against a **wall-clock** start time → nonsensical (often negative) delays.
- `JobExecutionTime` reflected wall time instead of the simulated clock.

All timing now uses `e.clock.Now()`.

### 2. Unguarded reschedule loop could spin (Medium)

`selectExecJobsOutForRescheduling` skipped duplicate `nextScheduled` entries with a bare `for nextScheduledContains(...) { next = j.next(next) }`. A schedule whose `next()` returns the zero time or fails to advance would either loop forever or fall through with a zero `next`, arming `AfterFunc` with a large negative duration that fires immediately and busy-loops the scheduler goroutine — the same failure class as #943, which was hardened elsewhere via `advancePastNow` but not here.

Extracted `advanceNextPastDuplicates` with the same guard; a zero/non-advancing `next` now removes the job as exhausted.

### 3. `stopScheduler` safety timer used the wall clock (Low)

Routed through `s.exec.clock` for consistency with `executor.stop`.

## Tests

- `TestScheduler_advanceNextPastDuplicates` — no-duplicate passthrough, advance-past-duplicate, and non-advancing/zero `next` → `ok=false`.
- `TestScheduler_advancePastNow` — direct coverage complementing the existing #943 integration test.
- `TestScheduler_ExecutionTimeUsesInjectedClock` — a job advances the fake clock by a known duration during execution; asserts the reported `JobExecutionTime` reflects the injected clock (fails at ~73µs vs 5s with the bug reintroduced).

Each guard/fix verified via negative control (reintroduce bug → test fails → restore).

## Verification

- `go test -race -count=1 -timeout 300s ./...` — pass
- `golangci-lint run ./...` — 0 issues
