### PR TITLE
refactor(scheduler): extract shared first-run logic from selectNewJob/selectStart

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -693,6 +693,72 @@ func (s *scheduler) selectJobOutRequest(out *jobOutRequest) {
 	close(out.outChan)
 }
 
+// dispatchJobRun sends an immediate run request for id to the executor,
+// respecting scheduler shutdown. Used for both start-immediately jobs and
+// grace-triggered fires.
+func (s *scheduler) dispatchJobRun(id uuid.UUID) {
+	select {
+	case <-s.shutdownCtx.Done():
+	case s.exec.jobsIn <- jobIn{
+		id:            id,
+		shouldSendOut: true,
+	}:
+	}
+}
+
+// prepareFirstRun resolves a job's initial run when the scheduler is
+// already running. It computes the first next-run time, applies
+// grace/drift handling (firstRunOrGrace), and then either dispatches an
+// immediate fire, arms the run timer, or reports that the job should be
+// dropped. On a non-drop result the returned job carries the updated
+// startTime/nextScheduled and must be stored by the caller. Returns
+// drop=true when the schedule is exhausted or is past its stop time, in
+// which case the caller should remove the job.
+//
+// This is the single source of truth shared by selectNewJob (adding a job
+// while running) and selectStart (starting the scheduler); the callers
+// differ only in their store/remove bookkeeping.
+func (s *scheduler) prepareFirstRun(j internalJob) (internalJob, bool) {
+	next := j.startTime
+	if j.startImmediately {
+		next = s.now()
+		s.dispatchJobRun(j.id)
+	} else {
+		if next.IsZero() {
+			next = j.next(s.now())
+		}
+
+		if next.Before(s.now()) {
+			var action firstRunAction
+			next, action = s.firstRunOrGrace(j, next)
+			switch action {
+			case firstRunDrop:
+				return j, true
+			case firstRunFireNow:
+				if !j.stopTime.IsZero() && !next.Before(j.stopTime) {
+					return j, true
+				}
+				s.dispatchJobRun(j.id)
+				j.startTime = next
+				j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
+				return j, false
+			}
+		}
+
+		if !j.stopTime.IsZero() && !next.Before(j.stopTime) {
+			return j, true
+		}
+
+		id := j.id
+		j.timer = s.exec.clock.AfterFunc(next.Sub(s.now()), func() {
+			s.dispatchJobRun(id)
+		})
+	}
+	j.startTime = next
+	j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
+	return j, false
+}
+
 // selectNewJob installs a job produced by addOrUpdateJob into s.jobs.
 // Runs the job's initial nextRun computation and, if the scheduler is
 // already started, wires it into the executor immediately. Signals
@@ -700,72 +766,16 @@ func (s *scheduler) selectJobOutRequest(out *jobOutRequest) {
 func (s *scheduler) selectNewJob(in newJobIn) {
 	j := in.job
 	if s.started.Load() {
-		next := j.startTime
-		if j.startImmediately {
-			next = s.now()
-			select {
-			case <-s.shutdownCtx.Done():
-			case s.exec.jobsIn <- jobIn{
-				id:            j.id,
-				shouldSendOut: true,
-			}:
-			}
-		} else {
-			if next.IsZero() {
-				next = j.next(s.now())
-			}
-
-			if next.Before(s.now()) {
-				var action firstRunAction
-				next, action = s.firstRunOrGrace(j, next)
-				switch action {
-				case firstRunDrop:
-					s.jobs[j.id] = j
-					in.cancel()
-					s.selectRemoveJob(j.id)
-					return
-				case firstRunFireNow:
-					if !j.stopTime.IsZero() && !next.Before(j.stopTime) {
-						s.jobs[j.id] = j
-						in.cancel()
-						s.selectRemoveJob(j.id)
-						return
-					}
-					select {
-					case <-s.shutdownCtx.Done():
-					case s.exec.jobsIn <- jobIn{
-						id:            j.id,
-						shouldSendOut: true,
-					}:
-					}
-					j.startTime = next
-					j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
-					s.jobs[j.id] = j
-					in.cancel()
-					return
-				}
-			}
-
-			if !j.stopTime.IsZero() && !next.Before(j.stopTime) {
-				s.jobs[j.id] = j
-				in.cancel()
-				s.selectRemoveJob(j.id)
-				return
-			}
-
-			id := j.id
-			j.timer = s.exec.clock.AfterFunc(next.Sub(s.now()), func() {
-				select {
-				case <-s.shutdownCtx.Done():
-				case s.exec.jobsIn <- jobIn{
-					id:            id,
-					shouldSendOut: true,
-				}:
-				}
-			})
+		updated, drop := s.prepareFirstRun(j)
+		j = updated
+		if drop {
+			// Store before removing so selectRemoveJob can find the
+			// brand-new job to cancel its context and notify monitors.
+			s.jobs[j.id] = j
+			in.cancel()
+			s.selectRemoveJob(j.id)
+			return
 		}
-		j.startTime = next
-		j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
 	}
 
 	s.jobs[j.id] = j
@@ -796,65 +806,12 @@ func (s *scheduler) selectStart() {
 
 	s.started.Store(true)
 	for id, j := range s.jobs {
-		next := j.startTime
-		if j.startImmediately {
-			next = s.now()
-			select {
-			case <-s.shutdownCtx.Done():
-			case s.exec.jobsIn <- jobIn{
-				id:            id,
-				shouldSendOut: true,
-			}:
-			}
-		} else {
-			if next.IsZero() {
-				next = j.next(s.now())
-			}
-			if next.Before(s.now()) {
-				var action firstRunAction
-				next, action = s.firstRunOrGrace(j, next)
-				switch action {
-				case firstRunDrop:
-					s.selectRemoveJob(id)
-					continue
-				case firstRunFireNow:
-					if !j.stopTime.IsZero() && !next.Before(j.stopTime) {
-						s.selectRemoveJob(id)
-						continue
-					}
-					select {
-					case <-s.shutdownCtx.Done():
-					case s.exec.jobsIn <- jobIn{
-						id:            id,
-						shouldSendOut: true,
-					}:
-					}
-					j.startTime = next
-					j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
-					s.jobs[id] = j
-					continue
-				}
-			}
-
-			if !j.stopTime.IsZero() && !next.Before(j.stopTime) {
-				s.selectRemoveJob(id)
-				continue
-			}
-
-			jobID := id
-			j.timer = s.exec.clock.AfterFunc(next.Sub(s.now()), func() {
-				select {
-				case <-s.shutdownCtx.Done():
-				case s.exec.jobsIn <- jobIn{
-					id:            jobID,
-					shouldSendOut: true,
-				}:
-				}
-			})
+		updated, drop := s.prepareFirstRun(j)
+		if drop {
+			s.selectRemoveJob(id)
+			continue
 		}
-		j.startTime = next
-		j.nextScheduled = insertNextScheduled(j.nextScheduled, next)
-		s.jobs[id] = j
+		s.jobs[id] = updated
 	}
 	select {
 	case <-s.shutdownCtx.Done():


### PR DESCRIPTION
> **Please review before merging — do not squash/merge yet.** This is a pure refactor; I'd like a maintainer pass on the extracted helper before it lands.

## Summary

`selectNewJob` (adding a job while the scheduler is running) and `selectStart` (starting the scheduler) carried **near-identical** first-run scheduling blocks:

- `startImmediately` dispatch on `jobsIn`
- `next.IsZero()` → `j.next(now)` fallback
- the `firstRunOrGrace` switch (`firstRunDrop` / `firstRunFireNow`)
- the `stopTime` guard
- `AfterFunc` timer arming
- `startTime` / `nextScheduled` bookkeeping

The `WithStartAtGrace` work (#945) had to be applied to **both** sites by hand. The only genuine difference between the two is the terminal bookkeeping: `selectNewJob` signals completion with `in.cancel()` and must store a brand-new job before removing it; `selectStart` iterates existing jobs and uses `continue`.

This was flagged as **M-B** in the fresh HEAD review: a maintainability hazard where the next scheduling change must be mirrored perfectly or the two paths silently diverge.

## Change

Extract a single source of truth:

- **`dispatchJobRun(id)`** — the repeated shutdown-aware `jobsIn` send, shared by start-immediately jobs and grace-triggered fires.
- **`prepareFirstRun(j) (internalJob, drop bool)`** — computes the first run, applies grace/drift handling, and either fires immediately, arms the run timer, or reports `drop=true`. On a non-drop result it returns the job with updated `startTime`/`nextScheduled` for the caller to store.

Both callers now own only their store-vs-remove semantics:

```go
// selectNewJob
if s.started.Load() {
    updated, drop := s.prepareFirstRun(j)
    j = updated
    if drop {
        s.jobs[j.id] = j // store first so selectRemoveJob can cancel ctx / notify
        in.cancel()
        s.selectRemoveJob(j.id)
        return
    }
}

// selectStart
updated, drop := s.prepareFirstRun(j)
if drop {
    s.selectRemoveJob(id)
    continue
}
s.jobs[id] = updated
```

## Notes for review

- **Behavior-preserving**: net `-123/+80`, no semantic changes intended. The drop path in `selectNewJob` still stores the brand-new job before `selectRemoveJob` so its context is cancelled and monitors are notified (`selectRemoveJob` early-returns if the id isn't in `s.jobs`).
- No new keys are added to `s.jobs` during the `selectStart` range loop (only existing-key updates and deletes), so map-mutation-during-range semantics are unchanged from before.

## Verification

- `go test -race -count=1 -timeout 300s ./...` — pass (existing start, new-job, `WithStartAtGrace`, and execution-time tests cover all paths)
- `golangci-lint run ./...` — 0 issues
