### PR TITLE
fix(executor): attribute scheduling delay to the tick that actually fired

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -482,7 +482,8 @@ func (e *executor) runJob(j internalJob, jIn jobIn) {
 		e.scheduler.notifyJobStarted(jobObj)
 		// Notify scheduling delay if job had a scheduled time
 		if len(j.nextScheduled) > 0 {
-			e.scheduler.notifyJobSchedulingDelay(jobObj, j.nextScheduled[0], actualStartTime)
+			scheduled := scheduledTimeForRun(j.nextScheduled, actualStartTime)
+			e.scheduler.notifyJobSchedulingDelay(jobObj, scheduled, actualStartTime)
 		}
 	}
 

--- a/util.go
+++ b/util.go
@@ -127,6 +127,27 @@ func nextScheduledContains(times []time.Time, t time.Time) bool {
 	return found
 }
 
+// scheduledTimeForRun returns the scheduled invocation time that best
+// corresponds to a run starting at actualStart: the latest entry at or
+// before actualStart, i.e. the schedule tick whose timer just fired.
+// Using the earliest entry (nextScheduled[0]) instead would overstate the
+// scheduling delay whenever an older, not-yet-pruned entry still lingers
+// in the slice or multiple ticks are pending. If every entry is in the
+// future relative to actualStart (not expected for a run dispatched by a
+// fired timer, but possible under clock skew), it falls back to the
+// earliest entry. Callers must ensure times is non-empty and sorted
+// ascending.
+func scheduledTimeForRun(times []time.Time, actualStart time.Time) time.Time {
+	idx, found := slices.BinarySearchFunc(times, actualStart, ascendingTime)
+	if found {
+		return times[idx]
+	}
+	if idx > 0 {
+		return times[idx-1]
+	}
+	return times[0]
+}
+
 // waitGroupWithMutex wraps sync.WaitGroup so that Add() cannot race
 // with Wait(). This addresses the classic "Add called after Wait
 // returned (or with counter == 0)" panic that sync.WaitGroup enforces:

--- a/util_test.go
+++ b/util_test.go
@@ -246,6 +246,58 @@ func TestNextScheduledContains(t *testing.T) {
 	assert.False(t, nextScheduledContains(nil, base))
 }
 
+func TestScheduledTimeForRun(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t0 := base
+	t1 := base.Add(time.Hour)
+	t2 := base.Add(2 * time.Hour)
+	slice := []time.Time{t0, t1, t2}
+
+	tests := []struct {
+		name        string
+		times       []time.Time
+		actualStart time.Time
+		want        time.Time
+	}{
+		{
+			name:        "single entry",
+			times:       []time.Time{t1},
+			actualStart: t1.Add(5 * time.Second),
+			want:        t1,
+		},
+		{
+			name:        "exact match returns that tick",
+			times:       slice,
+			actualStart: t1,
+			want:        t1,
+		},
+		{
+			name:        "between ticks returns the latest at-or-before",
+			times:       slice,
+			actualStart: t1.Add(30 * time.Minute),
+			want:        t1,
+		},
+		{
+			name:        "start after all ticks returns the latest",
+			times:       slice,
+			actualStart: t2.Add(time.Hour),
+			want:        t2,
+		},
+		{
+			name:        "start before all ticks falls back to earliest",
+			times:       slice,
+			actualStart: base.Add(-time.Hour),
+			want:        t0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scheduledTimeForRun(tt.times, tt.actualStart)
+			assert.True(t, got.Equal(tt.want), "got %s, want %s", got, tt.want)
+		})
+	}
+}
+
 func TestNextScheduledContains_MonotonicMismatch(t *testing.T) {
 	// slices.Contains uses ==, which compares monotonic readings.
 	// nextScheduledContains uses time.Compare via ascendingTime, so


### PR DESCRIPTION

### What does this do?
notifyJobSchedulingDelay always used j.nextScheduled[0] (the earliest pending tick) as the scheduled time. When more than one tick is present in nextScheduled — an older entry that hasn't been pruned yet, or several pending ticks — the earliest entry is not the one whose timer fired for this run, so JobSchedulingDelay(scheduledTime, actualStartTime) overstates the delay.

Introduce scheduledTimeForRun(times, actualStart): the latest entry at or before actualStart (the tick that just fired), falling back to the earliest entry only when every entry is in the future (not expected for a timer-dispatched run, but possible under clock skew). The common single-entry case is unchanged.

Adds a table-driven unit test covering single-entry, exact-match, between-ticks, after-all-ticks, and before-all-ticks cases.


### Which issue(s) does this PR fix/relate to?
<!--- Put `Resolves #XXX` here to auto-close the issue that your PR fixes (if such) --->


### List any changes that modify/break current functionality


### Have you included tests for your changes?


### Did you document any new/modified functionality?

- [ ] Updated `example_test.go`
- [ ] Updated `README.md`

### Notes
